### PR TITLE
feat: add oas2 support

### DIFF
--- a/internal/provider/apispecification_resource.go
+++ b/internal/provider/apispecification_resource.go
@@ -75,10 +75,11 @@ func (r *APISpecificationResource) Schema(ctx context.Context, req resource.Sche
 				MarkdownDescription: `The type of specification being stored. This allows us to render the specification correctly.` + "\n" +
 					`` + "\n" +
 					`If this field is not set, it will be autodetected from ` + "`" + `content` + "`" + `` + "\n" +
-					`must be one of ["oas3", "asyncapi"]`,
+					`must be one of ["oas3", "oas2", "asyncapi"]`,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"oas3",
+						"oas2",
 						"asyncapi",
 					),
 				},


### PR DESCRIPTION
Adds OAS 2 support. The UI already supports this decently (the specifications endpoint still returns oas3 even though it's oas2 - but the ui does show OAS 2)