### PR TITLE
chore(ci): run 'make speakeasy' on auto-update PRs 

### DIFF
--- a/.github/workflows/generate-speakeasy-on-pr.yaml
+++ b/.github/workflows/generate-speakeasy-on-pr.yaml
@@ -1,8 +1,9 @@
 name: Run Speakeasy on PR Open
 
 on:
-  pull_request:
-    types: [opened]
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened]
 
 permissions:
   contents: write

--- a/.github/workflows/generate-speakeasy-on-pr.yaml
+++ b/.github/workflows/generate-speakeasy-on-pr.yaml
@@ -1,0 +1,39 @@
+name: Run Speakeasy on PR Open
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  speakeasy-on-pr-open:
+    if: ${{ github.event.pull_request.head.ref == 'feat/platform-api-automated-update' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: speakeasy-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Speakeasy
+        run: make speakeasy
+
+      - name: Commit & push changes (if any)
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add -A
+            git commit -m "chore(ci): speakeasy auto-update on PR open"
+            git push
+          else
+            echo "No changes to commit."
+          fi
+


### PR DESCRIPTION
### Summary

On auto-update PRs like https://github.com/Kong/terraform-provider-konnect-beta/pull/76, I want to run `make speakeasy` and push changes to the same branch.
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [ ] Features being added are live
- [ ] Added/updated examples (if applicable)  
- [ ] Added/updated acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [ ] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
