### PR TITLE
chore: add harden runner step to CI

### DIFF
--- a/.github/workflows/provider-tests.yaml
+++ b/.github/workflows/provider-tests.yaml
@@ -18,6 +18,10 @@ jobs:
         terraform-version:
           - "1.11.*"
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           # Allow goreleaser to access older tag information.

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,6 +6,10 @@ jobs:
   ensure-pinned-actions:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Ensure SHA pinned actions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:


### PR DESCRIPTION
### Summary
This PR adds harden-runner step to all workflows in CI, allowing it to monitor egress.
Example: https://app.stepsecurity.io/github/Kong/terraform-provider-konnect-beta/actions/runs/18094780466

This has been https://github.com/Kong/deck/pull/1687, and https://github.com/Kong/terraform-provider-konnect/pull/223 before.

### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [ ] Features being added are live
- [ ] Added/updated examples (if applicable)  
- [ ] Added/updated acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
