### PR TITLE
ci(.github): fix 'Run Speakeasy on PR' workflow by specifying branch to checkout

### DIFF
--- a/.github/workflows/generate-speakeasy-on-pr.yaml
+++ b/.github/workflows/generate-speakeasy-on-pr.yaml
@@ -33,7 +33,9 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          ref: ${{ github.head_ref }}
           path: repo
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0


### PR DESCRIPTION
### Summary

Workflow failed on push https://github.com/Kong/terraform-provider-konnect-beta/actions/runs/18188164798/job/51776996554, the PR specifies the branch to checkout.
