### PR TITLE
Release/0.11.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 2.0.0
   speakeasyVersion: 1.602.0
   generationVersion: 2.681.1
-  releaseVersion: 0.10.0
-  configChecksum: 8914c62a6018729795feae7afdbfc793
+  releaseVersion: 0.11.0
+  configChecksum: bfdd9b7acdffef9635856c9bd870ea83
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     konnect-beta = {
       source  = "kong/konnect-beta"
-      version = "0.10.0"
+      version = "0.11.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     konnect-beta = {
       source  = "kong/konnect-beta"
-      version = "0.10.0"
+      version = "0.11.0"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -24,7 +24,7 @@ generation:
 go:
   version: 1.24.1
 terraform:
-  version: 0.10.0
+  version: 0.11.0
   additionalDataSources: []
   additionalDependencies:
     github.com/Kong/shared-speakeasy/customtypes: v0.2.3

--- a/internal/sdk/konnectbeta.go
+++ b/internal/sdk/konnectbeta.go
@@ -198,9 +198,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *KonnectBeta {
 	sdk := &KonnectBeta{
-		SDKVersion: "0.10.0",
+		SDKVersion: "0.11.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.10.0 2.681.1 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.11.0 2.681.1 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
### Summary

Add support for proto `oneOf`, fix and enable failed unit test.
  
### Issues resolved
- https://github.com/Kong/terraform-provider-konnect-beta/issues/87
- https://github.com/kumahq/kuma/issues/13772

### Related PRs on platform-api (if any)
- https://github.com/Kong/platform-api/pull/1863

### Checklist ✅ 
- [x] Features being added are live
- [x] Added/updated examples (if applicable)  
- [x] Added/updated acceptance tests (if applicable)  
- [x] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
