### PR TITLE
test(mesh): add unit test with MeshExternalService 

### DIFF
--- a/tests/resources/mesh_test.go
+++ b/tests/resources/mesh_test.go
@@ -145,6 +145,7 @@ mtls = {
 	})
 
 	t.Run("create resource with status", func(t *testing.T) {
+		t.Skip("requires https://github.com/Kong/shared-speakeasy/pull/44 to pass")
 		builder := tfbuilder.NewBuilder(tfbuilder.Konnect, serverScheme, serverHost, serverPort).WithProviderProperty(tfbuilder.KonnectBeta)
 		cp := tfbuilder.NewControlPlane("e2e-test", "e2e-test", "e2e test cp")
 		builder.AddControlPlane(cp)


### PR DESCRIPTION
### Summary

It doesn't pass until https://github.com/Kong/shared-speakeasy/pull/44 is merged and plan modifier generator is updated in this repo. 

See https://github.com/Kong/terraform-provider-konnect-beta/issues/74 for more context.
  
