### PR TITLE
ci(renovate): initial setup

### DIFF
--- a/.github/workflows/generate-speakeasy-on-pr.yaml
+++ b/.github/workflows/generate-speakeasy-on-pr.yaml
@@ -2,7 +2,15 @@ name: Run Speakeasy on PR Open
 
 on:
   pull_request:
-    types: [opened]
+    paths-ignore:
+      - '.github/**'
+      - 'examples/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: 'feat/platform-api-automated-update'
 
 permissions:
   contents: write
@@ -10,8 +18,13 @@ permissions:
 
 jobs:
   speakeasy-on-pr-open:
+    env:
+      REF: ${{ github.event.pull_request.head.ref || github.event.inputs.branch }}
     name: Run Speakeasy on PR Open
-    if: ${{ github.event.pull_request.head.ref == 'feat/platform-api-automated-update' }}
+    if: github.event.pull_request.head.ref == 'feat/platform-api-automated-update' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'mend[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: speakeasy-${{ github.event.pull_request.number }}
@@ -30,12 +43,20 @@ jobs:
           mkdir -p ~/.speakeasy
           echo 'speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}' > ~/.speakeasy/config.yaml
 
+      - name: Generate GitHub app token
+        id: github-app-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.KONG_MESH_APP_ID }}
+          private-key: ${{ secrets.KONG_MESH_APP_PRIVATE_KEY }}
+
       - name: Checkout PR branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ env.REF }}
           path: repo
           fetch-depth: 0
+          token: ${{ steps.github-app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -52,8 +73,8 @@ jobs:
       - name: Set up Git identity
         working-directory: repo
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "kong-mesh[bot]"
+          git config user.email "123109030+kong-mesh[bot]@users.noreply.github.com"
 
       - name: Run Generators
         working-directory: repo
@@ -69,4 +90,3 @@ jobs:
           else
             echo "No changes to commit."
           fi
-

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ dev/use-local-shared-speakeasy:
 acceptance:
 	@TF_ACC=1 go test -count=1 -v ./tests/resources
 
+# renovate: datasource=go depName=Kong/shared-speakeasy/resource_plan_modifier packageName=github.com/Kong/shared-speakeasy/generators/resource_plan_modifier
+RESOURCE_PLAN_MODIFIER_VERSION := v0.0.8
+
 .PHONY: generate-plan-modifiers
 generate-plan-modifiers:
 	# MeshControlPlane is identfied by uuid so we can skip it
@@ -56,5 +59,5 @@ generate-plan-modifiers:
 	| sed 's/Resource$$//' \
 	| grep -v "MeshControlPlane" \
 	| xargs -n1 -I{} sh -c '\
-		go run github.com/Kong/shared-speakeasy/generators/resource_plan_modifier@v0.0.8 \
+		go run github.com/Kong/shared-speakeasy/generators/resource_plan_modifier@$(RESOURCE_PLAN_MODIFIER_VERSION) \
 		internal/provider/$$(echo {} | tr A-Z a-z)_resource_plan_modify.go {} terraform-provider-konnect-beta'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "Kong/public-shared-renovate",
+    "Kong/public-shared-renovate//overrides/security-labels(area/security)",
+    ":combinePatchMinorReleases",
+    ":disableRateLimiting",
+    ":semanticCommitTypeAll(chore)",
+    "docker:pinDigests",
+    "schedule:daily"
+  ],
+  "enabledManagers": [
+    "custom.jsonata",
+    "custom.regex",
+    "github-actions"
+  ],
+  "internalChecksFilter": "strict",
+  "keepUpdatedLabel": "renovate/keep-updated",
+  "rebaseWhen": "conflicted",
+  "prTitleStrict": true,
+  "vulnerabilityAlerts": { "commitMessageSuffix": "" },
+  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
+  "customManagers": [
+    {
+      "description": "Manage Go module versions inside terraform.additionalDependencies in gen.yaml",
+      "customType": "jsonata",
+      "fileFormat": "yaml",
+      "managerFilePatterns": ["/^gen\\.yaml$/"],
+      "matchStrings": [
+        "$each(terraform.additionalDependencies, function($v, $k) { {\"depName\":$k, \"currentValue\": $v}})"
+      ],
+      "datasourceTemplate": "go"
+    },
+    {
+      "description": "Manage speakeasyVersion in .speakeasy/workflow.yaml",
+      "customType": "jsonata",
+      "fileFormat": "yaml",
+      "managerFilePatterns": ["/^\\.speakeasy/workflow\\.yaml$/"],
+      "matchStrings": [
+        "{ \"depName\": \"speakeasy-api/speakeasy\", \"currentValue\": speakeasyVersion }"
+      ],
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "v(?<version>.*)"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["speakeasy-api/speakeasy"],
+      "minimumReleaseAge": "24h"
+    },
+    {
+      "matchPackageNames": ["{github.com/,}[Kk]ong/shared-speakeasy/**"],
+      "minimumReleaseAge": "0"
+    },
+    {
+      "description": [
+        "Catch-all rule that applies the standard commit message format for all dependencies",
+        "",
+        "This rule extends the shared baseline preset to ensure consistent commit message",
+        "action/topic/extra rendering across all updates. It must be the last packageRule",
+        "in renovate.json, so it takes precedence after any more specific rules."
+      ],
+      "matchDepNames": "*",
+      "extends": [
+        "Kong/public-shared-renovate//scoped/kuma/commit-message-baseline"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
Sets up renovate so we stay up to date with updates in go modules, makefiles and gen.yaml.
  
### Issues resolved
- https://github.com/Kong/terraform-provider-konnect-beta/issues/88

### Related PRs on platform-api (if any)
- none

### Checklist ✅ 
- [X] Features being added are live - N/A
- [X] Added/updated examples (if applicable) - N/A
- [X] Added/updated acceptance tests (if applicable) - N/A
- [X] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes - N/A - not a product change
- [X] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
