### PR TITLE
chore: bump speakeasy to v1.653.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,15 +3,15 @@ id: e3bbe1e9-fe63-436b-a42c-05e3e3f77633
 management:
   docChecksum: 0e25c36053ea26b820ca120b8c26cc81
   docVersion: 2.0.0
-  speakeasyVersion: 1.648.0
-  generationVersion: 2.737.0
+  speakeasyVersion: 1.653.0
+  generationVersion: 2.748.0
   releaseVersion: 0.12.0
-  configChecksum: 8ba6449d834f96940e647091e9c3f3be
+  configChecksum: e4a6c9659fae575ed0238f6d79c78557
 features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.0
-    core: 3.46.5
+    core: 3.46.8
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     globalSecurity: 2.82.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,11 +1,11 @@
-speakeasyVersion: 1.648.0
+speakeasyVersion: 1.653.0
 sources: {}
 targets:
     terraform:
         source: kong
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.648.0
+    speakeasyVersion: 1.653.0
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.648.0
+speakeasyVersion: 1.653.0
 sources:
     kong:
         inputs:

--- a/gen.yaml
+++ b/gen.yaml
@@ -19,6 +19,7 @@ generation:
     hoistGlobalSecurity: true
   schemas:
     allOfMergeStrategy: shallowMerge
+  requestBodyFieldName: ""
   tests:
     generateTests: true
     generateNewTests: false
@@ -44,6 +45,7 @@ terraform:
   author: kong
   baseErrorName: KonnectBetaError
   defaultErrorName: SDKError
+  enableOperationSecurity: false
   enableOperationServers: false
   enableTypeDeduplication: true
   environmentVariables:

--- a/internal/provider/portal_data_source_sdk.go
+++ b/internal/provider/portal_data_source_sdk.go
@@ -26,6 +26,9 @@ func (r *PortalDataSourceModel) RefreshFromSharedListPortalsResponse(ctx context
 			return diags
 		}
 
+		r.Number = types.Float64Value(resp.Meta.Page.Number)
+		r.Size = types.Float64Value(resp.Meta.Page.Size)
+		r.Total = types.Float64Value(resp.Meta.Page.Total)
 	}
 
 	return diags

--- a/internal/sdk/konnectbeta.go
+++ b/internal/sdk/konnectbeta.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 2.0.0 and generator version 2.737.0
+// Generated from OpenAPI doc version 2.0.0 and generator version 2.748.0
 
 import (
 	"context"
@@ -204,7 +204,7 @@ func New(opts ...SDKOption) *KonnectBeta {
 	sdk := &KonnectBeta{
 		SDKVersion: "0.12.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.12.0 2.737.0 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.12.0 2.748.0 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
### Summary
Bumping speakeasy to 1.653.0
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [ ] Features being added are live
- [ ] Added/updated examples (if applicable)  
- [ ] Added/updated acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [ ] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
