### PR TITLE
fix(portal): use random number to not get conflicts on resources

### DIFF
--- a/tests/resources/testdata/TestPortal/smoke-test/portal.tf
+++ b/tests/resources/testdata/TestPortal/smoke-test/portal.tf
@@ -1,3 +1,7 @@
+resource "random_id" "hostname_suffix" {
+  byte_length = 4
+}
+
 resource "konnect_portal" "my_portal" {
   provider                             = konnect-beta
   name                                 = "Hello World"
@@ -19,7 +23,7 @@ resource "konnect_portal_custom_domain" "my_portalcustomdomain" {
   provider  = konnect-beta
   enabled   = false
   # From the API: Custom hostnames ending in example.com, example.net, or example.org are prohibited
-  hostname  = "tfautomatedtests.mheap.xyz"
+  hostname  = "tfautomatedtests-${random_id.hostname_suffix.hex}.mheap.xyz"
   portal_id = konnect_portal.my_portal.id
   ssl = {
     domain_verification_method = "http"

--- a/tests/resources/testdata/TestPortal/smoke-test/provider.tf
+++ b/tests/resources/testdata/TestPortal/smoke-test/provider.tf
@@ -3,6 +3,9 @@ terraform {
     konnect = {
       source = "kong/konnect"
     }
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }
 


### PR DESCRIPTION
### Summary
  
### Issues resolved
- https://github.com/Kong/terraform-provider-konnect-beta/actions/runs/19568437901/job/56036995401?pr=152#step:8:111

### Related PRs on platform-api (if any)
- none

### Checklist ✅ 
- [x] Features being added are live
- [x] Added/updated examples (if applicable)  
- [x] Added/updated acceptance tests (if applicable)  
- [x] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
