### PR TITLE
fix: Event Gateway virtual cluster update operation

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,15 +3,15 @@ id: e3bbe1e9-fe63-436b-a42c-05e3e3f77633
 management:
   docChecksum: d3c2f54b944416ad3ad055068baac0df
   docVersion: 2.0.0
-  speakeasyVersion: 1.653.0
-  generationVersion: 2.748.0
+  speakeasyVersion: 1.661.1
+  generationVersion: 2.763.2
   releaseVersion: 0.12.1
-  configChecksum: 6c8b646447ad45c68f441a62cfa6a0c0
+  configChecksum: 1cd2b4a7a4c996834ab0be225278d4c7
 features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.0
-    core: 3.46.8
+    core: 3.46.18
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     globalSecurity: 2.82.1
@@ -22,7 +22,7 @@ features:
     nullables: 0.0.0
     retries: 2.81.4
     typeOverrides: 2.81.1
-    unions: 2.82.2
+    unions: 2.82.5
 generatedFiles:
   - .gitattributes
   - USAGE.md

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,11 +1,11 @@
-speakeasyVersion: 1.653.0
+speakeasyVersion: 1.661.1
 sources: {}
 targets:
     terraform:
         source: kong
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.653.0
+    speakeasyVersion: 1.661.1
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.653.0
+speakeasyVersion: 1.661.1
 sources:
     kong:
         inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## 0.13.0
+> Released on 2025/11/??
 
 ### Features
 * Support `force_destroy` parameter to optionally delete resources associated with `konnect_auth_server`
+
+### Bug fixes
+* Fix update operation on `konnect_event_gateway_virtual_cluster` resource when `sasl_plain` authentication scheme is used
 
 ## 0.12.1
 > Released on 2025/11/13

--- a/docs/resources/api_version.md
+++ b/docs/resources/api_version.md
@@ -50,7 +50,7 @@ Optional:
 
 Read-Only:
 
-- `type` (String) The type of specification being stored. This allows us to render the specification correctly. must be one of ["oas2", "oas3", "asyncapi"]
+- `type` (String) The type of specification being stored. This allows us to render the specification correctly.
 - `validation_messages` (Attributes List) The errors that occurred while parsing the API version spec. (see [below for nested schema](#nestedatt--spec--validation_messages))
 
 <a id="nestedatt--spec--validation_messages"></a>

--- a/docs/resources/mesh_external_service.md
+++ b/docs/resources/mesh_external_service.md
@@ -268,7 +268,7 @@ Producers of specific condition types may define expected values and meanings fo
 and whether the values are considered a guaranteed API.
 The value should be a CamelCase string.
 This field may not be empty.
-- `status` (String) status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]
+- `status` (String) status of the condition, one of True, False, Unknown.
 - `type` (String) type of condition in CamelCase or in foo.example.com/CamelCase.
 
 

--- a/docs/resources/mesh_identity.md
+++ b/docs/resources/mesh_identity.md
@@ -337,7 +337,7 @@ Producers of specific condition types may define expected values and meanings fo
 and whether the values are considered a guaranteed API.
 The value should be a CamelCase string.
 This field may not be empty.
-- `status` (String) status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]
+- `status` (String) status of the condition, one of True, False, Unknown.
 - `type` (String) type of condition in CamelCase or in foo.example.com/CamelCase.
 
 ## Import

--- a/docs/resources/mesh_multi_zone_service.md
+++ b/docs/resources/mesh_multi_zone_service.md
@@ -148,7 +148,7 @@ Producers of specific condition types may define expected values and meanings fo
 and whether the values are considered a guaranteed API.
 The value should be a CamelCase string.
 This field may not be empty.
-- `status` (String) status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]
+- `status` (String) status of the condition, one of True, False, Unknown.
 - `type` (String) type of condition in CamelCase or in foo.example.com/CamelCase.
 
 

--- a/docs/resources/mesh_service.md
+++ b/docs/resources/mesh_service.md
@@ -194,7 +194,7 @@ Producers of specific condition types may define expected values and meanings fo
 and whether the values are considered a guaranteed API.
 The value should be a CamelCase string.
 This field may not be empty.
-- `status` (String) status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]
+- `status` (String) status of the condition, one of True, False, Unknown.
 - `type` (String) type of condition in CamelCase or in foo.example.com/CamelCase.
 
 
@@ -212,7 +212,7 @@ Read-Only:
 
 Read-Only:
 
-- `status` (String) must be one of ["Ready", "NotReady"]
+- `status` (String)
 
 
 <a id="nestedatt--status--vips"></a>

--- a/docs/resources/portal_custom_domain.md
+++ b/docs/resources/portal_custom_domain.md
@@ -39,7 +39,7 @@ resource "konnect_portal_custom_domain" "my_portalcustomdomain" {
 
 ### Read-Only
 
-- `cname_status` (String) must be one of ["verified", "pending"]
+- `cname_status` (String)
 - `created_at` (String) An ISO-8601 timestamp representation of entity creation date.
 - `updated_at` (String) An ISO-8601 timestamp representation of entity update date.
 
@@ -58,7 +58,7 @@ Read-Only:
 - `expires_at` (String) An ISO-8601 timestamp representation of the ssl certificate expiration date.
 - `uploaded_at` (String) An ISO-8601 timestamp representation of the ssl certificate upload date.
 - `validation_errors` (List of String)
-- `verification_status` (String) must be one of ["verified", "pending", "error"]
+- `verification_status` (String)
 
 ## Import
 

--- a/gen.yaml
+++ b/gen.yaml
@@ -45,6 +45,7 @@ terraform:
   author: kong
   baseErrorName: KonnectBetaError
   defaultErrorName: SDKError
+  enableCustomCodeRegions: false
   enableOperationSecurity: false
   enableOperationServers: false
   enableTypeDeduplication: true
@@ -55,6 +56,7 @@ terraform:
       providerAttribute: system_account_access_token
     - env: KONNECT_SERVER_URL
       providerAttribute: server_url
+  excludeEmptyObjectSchemas: false
   imports:
     option: openapi
     paths:
@@ -64,5 +66,6 @@ terraform:
       shared: shared
       webhooks: webhooks
   includeEmptyObjects: false
+  inferUnionDiscriminators: false
   packageName: konnect-beta
-  unionDeserializationStrategy: populated-fields
+  unionStrategy: populated-fields

--- a/internal/provider/api_resource.go
+++ b/internal/provider/api_resource.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -21,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	"regexp"
 )
 
@@ -84,9 +82,6 @@ func (r *APIResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -148,9 +143,6 @@ func (r *APIResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 					},
 				},
 				Description: `The list of portals which this API is published to.`,
-				Validators: []validator.List{
-					listvalidator.UniqueValues(),
-				},
 			},
 			"slug": schema.StringAttribute{
 				Computed: true,
@@ -175,9 +167,6 @@ func (r *APIResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"version": schema.StringAttribute{
 				Computed:    true,
@@ -495,7 +484,10 @@ func (r *APIResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/api_resource_sdk.go
+++ b/internal/provider/api_resource_sdk.go
@@ -129,10 +129,10 @@ func (r *APIResourceModel) ToSharedCreateAPIRequest(ctx context.Context) (*share
 		slug = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -191,10 +191,10 @@ func (r *APIResourceModel) ToSharedUpdateAPIRequest(ctx context.Context) (*share
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/apidocument_resource.go
+++ b/internal/provider/apidocument_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	"regexp"
 )
 
@@ -71,9 +70,6 @@ func (r *APIDocumentResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -121,9 +117,6 @@ func (r *APIDocumentResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -183,6 +176,13 @@ func (r *APIDocumentResource) Create(ctx context.Context, req resource.CreateReq
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -359,7 +359,10 @@ func (r *APIDocumentResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apiimplementation_resource.go
+++ b/internal/provider/apiimplementation_resource.go
@@ -16,11 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
 
@@ -69,9 +67,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -93,11 +88,9 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 				Description: `A Gateway service that implements an API`,
 			},
 			"service_reference": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"created_at": schema.StringAttribute{
@@ -106,9 +99,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -122,7 +112,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
 							objectplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 						},
 						Attributes: map[string]schema.Attribute{
 							"control_plane_id": schema.StringAttribute{
@@ -130,7 +119,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 								Optional: true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplaceIfConfigured(),
-									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
 								Description: `Not Null; Requires replacement if changed.`,
 								Validators: []validator.String{
@@ -142,7 +130,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 								Optional: true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplaceIfConfigured(),
-									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
 								Description: `Not Null; Requires replacement if changed.`,
 								Validators: []validator.String{
@@ -158,9 +145,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 				},
 				Description: `A gateway service that implements an API. Requires replacement if changed.`,
@@ -171,9 +155,6 @@ func (r *APIImplementationResource) Schema(ctx context.Context, req resource.Sch
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -233,6 +214,13 @@ func (r *APIImplementationResource) Create(ctx context.Context, req resource.Cre
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -373,7 +361,10 @@ func (r *APIImplementationResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apipublication_resource.go
+++ b/internal/provider/apipublication_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -82,9 +81,6 @@ func (r *APIPublicationResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"portal_id": schema.StringAttribute{
 				Required:    true,
@@ -96,9 +92,6 @@ func (r *APIPublicationResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -349,7 +342,10 @@ func (r *APIPublicationResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apipublication_resource_sdk.go
+++ b/internal/provider/apipublication_resource_sdk.go
@@ -105,8 +105,8 @@ func (r *APIPublicationResourceModel) ToSharedAPIPublication(ctx context.Context
 	var authStrategyIds []string
 	if r.AuthStrategyIds != nil {
 		authStrategyIds = make([]string, 0, len(r.AuthStrategyIds))
-		for _, authStrategyIdsItem := range r.AuthStrategyIds {
-			authStrategyIds = append(authStrategyIds, authStrategyIdsItem.ValueString())
+		for authStrategyIdsIndex := range r.AuthStrategyIds {
+			authStrategyIds = append(authStrategyIds, r.AuthStrategyIds[authStrategyIdsIndex].ValueString())
 		}
 	}
 	visibility := new(shared.APIPublicationVisibility)

--- a/internal/provider/apispecification_resource.go
+++ b/internal/provider/apispecification_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *APISpecificationResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -99,9 +95,6 @@ func (r *APISpecificationResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"validation_messages": schema.ListNestedAttribute{
 				Computed: true,
@@ -181,6 +174,13 @@ func (r *APISpecificationResource) Create(ctx context.Context, req resource.Crea
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -357,7 +357,10 @@ func (r *APISpecificationResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apiversion_resource.go
+++ b/internal/provider/apiversion_resource.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/listplanmodifier"
@@ -20,7 +18,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -65,9 +62,6 @@ func (r *APIVersionResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -88,14 +82,7 @@ func (r *APIVersionResource) Schema(ctx context.Context, req resource.SchemaRequ
 						PlanModifiers: []planmodifier.String{
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
-						Description: `The type of specification being stored. This allows us to render the specification correctly. must be one of ["oas2", "oas3", "asyncapi"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"oas2",
-								"oas3",
-								"asyncapi",
-							),
-						},
+						Description: `The type of specification being stored. This allows us to render the specification correctly.`,
 					},
 					"validation_messages": schema.ListNestedAttribute{
 						Computed: true,
@@ -125,9 +112,6 @@ func (r *APIVersionResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"version": schema.StringAttribute{
 				Optional:    true,
@@ -191,6 +175,13 @@ func (r *APIVersionResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -404,7 +395,10 @@ func (r *APIVersionResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/authserver_resource.go
+++ b/internal/provider/authserver_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -71,9 +70,6 @@ func (r *AuthServerResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,
@@ -150,9 +146,6 @@ func (r *AuthServerResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -212,6 +205,13 @@ func (r *AuthServerResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -388,7 +388,10 @@ func (r *AuthServerResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/authserver_resource_sdk.go
+++ b/internal/provider/authserver_resource_sdk.go
@@ -119,18 +119,18 @@ func (r *AuthServerResourceModel) ToSharedCreateAuthServer(ctx context.Context) 
 		signingAlgorithm = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
 		labels[labelsKey] = labelsInst
 	}
 	trustedOrigins := make([]string, 0, len(r.TrustedOrigins))
-	for _, trustedOriginsItem := range r.TrustedOrigins {
-		trustedOrigins = append(trustedOrigins, trustedOriginsItem.ValueString())
+	for trustedOriginsIndex := range r.TrustedOrigins {
+		trustedOrigins = append(trustedOrigins, r.TrustedOrigins[trustedOriginsIndex].ValueString())
 	}
 	out := shared.CreateAuthServer{
 		Name:             name,
@@ -174,10 +174,10 @@ func (r *AuthServerResourceModel) ToSharedUpdateAuthServer(ctx context.Context) 
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -185,8 +185,8 @@ func (r *AuthServerResourceModel) ToSharedUpdateAuthServer(ctx context.Context) 
 		}
 	}
 	trustedOrigins := make([]string, 0, len(r.TrustedOrigins))
-	for _, trustedOriginsItem := range r.TrustedOrigins {
-		trustedOrigins = append(trustedOrigins, trustedOriginsItem.ValueString())
+	for trustedOriginsIndex := range r.TrustedOrigins {
+		trustedOrigins = append(trustedOrigins, r.TrustedOrigins[trustedOriginsIndex].ValueString())
 	}
 	out := shared.UpdateAuthServer{
 		Name:             name,

--- a/internal/provider/authserverclaims_resource.go
+++ b/internal/provider/authserverclaims_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -67,9 +66,6 @@ func (r *AuthServerClaimsResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"enabled": schema.BoolAttribute{
 				Computed:    true,
@@ -112,9 +108,6 @@ func (r *AuthServerClaimsResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"value": schema.StringAttribute{
 				Required:    true,
@@ -357,7 +350,10 @@ func (r *AuthServerClaimsResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/authserverclaims_resource_sdk.go
+++ b/internal/provider/authserverclaims_resource_sdk.go
@@ -134,8 +134,8 @@ func (r *AuthServerClaimsResourceModel) ToSharedCreateClaim(ctx context.Context)
 		includeInAllScopes = nil
 	}
 	includeInScopes := make([]string, 0, len(r.IncludeInScopes))
-	for _, includeInScopesItem := range r.IncludeInScopes {
-		includeInScopes = append(includeInScopes, includeInScopesItem.ValueString())
+	for includeInScopesIndex := range r.IncludeInScopes {
+		includeInScopes = append(includeInScopes, r.IncludeInScopes[includeInScopesIndex].ValueString())
 	}
 	enabled := new(bool)
 	if !r.Enabled.IsUnknown() && !r.Enabled.IsNull() {
@@ -183,8 +183,8 @@ func (r *AuthServerClaimsResourceModel) ToSharedUpdateClaim(ctx context.Context)
 		includeInAllScopes = nil
 	}
 	includeInScopes := make([]string, 0, len(r.IncludeInScopes))
-	for _, includeInScopesItem := range r.IncludeInScopes {
-		includeInScopes = append(includeInScopes, includeInScopesItem.ValueString())
+	for includeInScopesIndex := range r.IncludeInScopes {
+		includeInScopes = append(includeInScopes, r.IncludeInScopes[includeInScopesIndex].ValueString())
 	}
 	enabled := new(bool)
 	if !r.Enabled.IsUnknown() && !r.Enabled.IsNull() {

--- a/internal/provider/authserverclients_resource.go
+++ b/internal/provider/authserverclients_resource.go
@@ -22,8 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
-	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -106,9 +104,6 @@ func (r *AuthServerClientsResource) Schema(ctx context.Context, req resource.Sch
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"grant_types": schema.ListAttribute{
 				Required:    true,
@@ -124,10 +119,6 @@ func (r *AuthServerClientsResource) Schema(ctx context.Context, req resource.Sch
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `The OAuth 2.0 client ID`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthBetween(1, 36),
-					stringvalidator.RegexMatches(regexp.MustCompile(`[-_\w]+`), "must match pattern "+regexp.MustCompile(`[-_\w]+`).String()),
-				},
 			},
 			"id_token_duration": schema.Int64Attribute{
 				Computed:    true,
@@ -186,9 +177,6 @@ func (r *AuthServerClientsResource) Schema(ctx context.Context, req resource.Sch
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -248,6 +236,13 @@ func (r *AuthServerClientsResource) Create(ctx context.Context, req resource.Cre
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -501,7 +496,10 @@ func (r *AuthServerClientsResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/authserverclients_resource_sdk.go
+++ b/internal/provider/authserverclients_resource_sdk.go
@@ -195,8 +195,8 @@ func (r *AuthServerClientsResourceModel) ToSharedCreateClient(ctx context.Contex
 		responseTypes = append(responseTypes, shared.ResponseType(responseTypesItem.ValueString()))
 	}
 	redirectUris := make([]string, 0, len(r.RedirectUris))
-	for _, redirectUrisItem := range r.RedirectUris {
-		redirectUris = append(redirectUris, redirectUrisItem.ValueString())
+	for redirectUrisIndex := range r.RedirectUris {
+		redirectUris = append(redirectUris, r.RedirectUris[redirectUrisIndex].ValueString())
 	}
 	loginURI := new(string)
 	if !r.LoginURI.IsUnknown() && !r.LoginURI.IsNull() {
@@ -223,14 +223,14 @@ func (r *AuthServerClientsResourceModel) ToSharedCreateClient(ctx context.Contex
 		allowAllScopes = nil
 	}
 	allowScopes := make([]string, 0, len(r.AllowScopes))
-	for _, allowScopesItem := range r.AllowScopes {
-		allowScopes = append(allowScopes, allowScopesItem.ValueString())
+	for allowScopesIndex := range r.AllowScopes {
+		allowScopes = append(allowScopes, r.AllowScopes[allowScopesIndex].ValueString())
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -277,8 +277,8 @@ func (r *AuthServerClientsResourceModel) ToSharedReplaceClient(ctx context.Conte
 		responseTypes = append(responseTypes, shared.ResponseType(responseTypesItem.ValueString()))
 	}
 	redirectUris := make([]string, 0, len(r.RedirectUris))
-	for _, redirectUrisItem := range r.RedirectUris {
-		redirectUris = append(redirectUris, redirectUrisItem.ValueString())
+	for redirectUrisIndex := range r.RedirectUris {
+		redirectUris = append(redirectUris, r.RedirectUris[redirectUrisIndex].ValueString())
 	}
 	loginURI := new(string)
 	if !r.LoginURI.IsUnknown() && !r.LoginURI.IsNull() {
@@ -305,8 +305,8 @@ func (r *AuthServerClientsResourceModel) ToSharedReplaceClient(ctx context.Conte
 		allowAllScopes = nil
 	}
 	allowScopes := make([]string, 0, len(r.AllowScopes))
-	for _, allowScopesItem := range r.AllowScopes {
-		allowScopes = append(allowScopes, allowScopesItem.ValueString())
+	for allowScopesIndex := range r.AllowScopes {
+		allowScopes = append(allowScopes, r.AllowScopes[allowScopesIndex].ValueString())
 	}
 	tokenEndpointAuthMethod := new(shared.TokenEndpointAuthMethod)
 	if !r.TokenEndpointAuthMethod.IsUnknown() && !r.TokenEndpointAuthMethod.IsNull() {
@@ -315,10 +315,10 @@ func (r *AuthServerClientsResourceModel) ToSharedReplaceClient(ctx context.Conte
 		tokenEndpointAuthMethod = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/authserverscopes_resource.go
+++ b/internal/provider/authserverscopes_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -66,9 +65,6 @@ func (r *AuthServerScopesResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"default": schema.BoolAttribute{
 				Computed:    true,
@@ -110,9 +106,6 @@ func (r *AuthServerScopesResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -172,6 +165,13 @@ func (r *AuthServerScopesResource) Create(ctx context.Context, req resource.Crea
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -348,7 +348,10 @@ func (r *AuthServerScopesResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/dashboard_resource.go
+++ b/internal/provider/dashboard_resource.go
@@ -68,9 +68,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"created_by": schema.StringAttribute{
 				Computed: true,
@@ -160,7 +157,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 							},
 							Attributes: map[string]schema.Attribute{
 								"chart": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"definition": schema.SingleNestedAttribute{
@@ -172,7 +168,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"choropleth_map": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"chart_title": schema.StringAttribute{
@@ -205,7 +200,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 														},
 														"donut": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"chart_title": schema.StringAttribute{
@@ -235,7 +229,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 														},
 														"horizontal_bar": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"chart_title": schema.StringAttribute{
@@ -273,7 +266,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 														},
 														"single_value": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"chart_title": schema.StringAttribute{
@@ -308,7 +300,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 														},
 														"timeseries_line": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"chart_title": schema.StringAttribute{
@@ -362,7 +353,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 													Optional: true,
 													Attributes: map[string]schema.Attribute{
 														"api_usage": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"datasource": schema.StringAttribute{
@@ -499,7 +489,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 																	Optional: true,
 																	Attributes: map[string]schema.Attribute{
 																		"absolute": schema.SingleNestedAttribute{
-																			Computed: true,
 																			Optional: true,
 																			Attributes: map[string]schema.Attribute{
 																				"end": schema.StringAttribute{
@@ -538,7 +527,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 																			},
 																		},
 																		"relative": schema.SingleNestedAttribute{
-																			Computed: true,
 																			Optional: true,
 																			Attributes: map[string]schema.Attribute{
 																				"time_range": schema.StringAttribute{
@@ -597,7 +585,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 															},
 														},
 														"llm_usage": schema.SingleNestedAttribute{
-															Computed: true,
 															Optional: true,
 															Attributes: map[string]schema.Attribute{
 																"datasource": schema.StringAttribute{
@@ -731,7 +718,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 																	Optional: true,
 																	Attributes: map[string]schema.Attribute{
 																		"absolute": schema.SingleNestedAttribute{
-																			Computed: true,
 																			Optional: true,
 																			Attributes: map[string]schema.Attribute{
 																				"end": schema.StringAttribute{
@@ -770,7 +756,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 																			},
 																		},
 																		"relative": schema.SingleNestedAttribute{
-																			Computed: true,
 																			Optional: true,
 																			Attributes: map[string]schema.Attribute{
 																				"time_range": schema.StringAttribute{
@@ -964,9 +949,6 @@ func (r *DashboardResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -1202,7 +1184,10 @@ func (r *DashboardResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/dashboard_resource_sdk.go
+++ b/internal/provider/dashboard_resource_sdk.go
@@ -259,23 +259,23 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 	name = r.Name.ValueString()
 
 	tiles := make([]shared.Tile, 0, len(r.Definition.Tiles))
-	for _, tilesItem := range r.Definition.Tiles {
-		if tilesItem.Chart != nil {
+	for tilesItem := range r.Definition.Tiles {
+		if r.Definition.Tiles[tilesItem].Chart != nil {
 			var col int64
-			col = tilesItem.Chart.Layout.Position.Col.ValueInt64()
+			col = r.Definition.Tiles[tilesItem].Chart.Layout.Position.Col.ValueInt64()
 
 			var row int64
-			row = tilesItem.Chart.Layout.Position.Row.ValueInt64()
+			row = r.Definition.Tiles[tilesItem].Chart.Layout.Position.Row.ValueInt64()
 
 			position := shared.Position{
 				Col: col,
 				Row: row,
 			}
 			var cols int64
-			cols = tilesItem.Chart.Layout.Size.Cols.ValueInt64()
+			cols = r.Definition.Tiles[tilesItem].Chart.Layout.Size.Cols.ValueInt64()
 
 			var rows int64
-			rows = tilesItem.Chart.Layout.Size.Rows.ValueInt64()
+			rows = r.Definition.Tiles[tilesItem].Chart.Layout.Size.Rows.ValueInt64()
 
 			size := shared.Size{
 				Cols: cols,
@@ -285,29 +285,29 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				Position: position,
 				Size:     size,
 			}
-			typeVar := shared.ChartTileType(tilesItem.Chart.Type.ValueString())
+			typeVar := shared.ChartTileType(r.Definition.Tiles[tilesItem].Chart.Type.ValueString())
 			var query shared.Query
 			var advancedQuery *shared.AdvancedQuery
-			if tilesItem.Chart.Definition.Query.APIUsage != nil {
-				datasource := shared.Datasource(tilesItem.Chart.Definition.Query.APIUsage.Datasource.ValueString())
-				metrics := make([]shared.AdvancedMetrics, 0, len(tilesItem.Chart.Definition.Query.APIUsage.Metrics))
-				for _, metricsItem := range tilesItem.Chart.Definition.Query.APIUsage.Metrics {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage != nil {
+				datasource := shared.Datasource(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Datasource.ValueString())
+				metrics := make([]shared.AdvancedMetrics, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Metrics))
+				for _, metricsItem := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Metrics {
 					metrics = append(metrics, shared.AdvancedMetrics(metricsItem.ValueString()))
 				}
 				var dimensions []shared.Dimensions
-				if tilesItem.Chart.Definition.Query.APIUsage.Dimensions != nil {
-					dimensions = make([]shared.Dimensions, 0, len(tilesItem.Chart.Definition.Query.APIUsage.Dimensions))
-					for _, dimensionsItem := range tilesItem.Chart.Definition.Query.APIUsage.Dimensions {
+				if r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Dimensions != nil {
+					dimensions = make([]shared.Dimensions, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Dimensions))
+					for _, dimensionsItem := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Dimensions {
 						dimensions = append(dimensions, shared.Dimensions(dimensionsItem.ValueString()))
 					}
 				}
-				filters := make([]shared.AdvancedFilters, 0, len(tilesItem.Chart.Definition.Query.APIUsage.Filters))
-				for _, filtersItem := range tilesItem.Chart.Definition.Query.APIUsage.Filters {
-					field := shared.Field(filtersItem.Field.ValueString())
-					operator := shared.Operator(filtersItem.Operator.ValueString())
+				filters := make([]shared.AdvancedFilters, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters))
+				for filtersIndex := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters {
+					field := shared.Field(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters[filtersIndex].Field.ValueString())
+					operator := shared.Operator(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters[filtersIndex].Operator.ValueString())
 					var value interface{}
-					if !filtersItem.Value.IsUnknown() && !filtersItem.Value.IsNull() {
-						_ = json.Unmarshal([]byte(filtersItem.Value.ValueString()), &value)
+					if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters[filtersIndex].Value.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters[filtersIndex].Value.IsNull() {
+						_ = json.Unmarshal([]byte(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Filters[filtersIndex].Value.ValueString()), &value)
 					}
 					filters = append(filters, shared.AdvancedFilters{
 						Field:    field,
@@ -316,25 +316,25 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 					})
 				}
 				granularity := new(shared.Granularity)
-				if !tilesItem.Chart.Definition.Query.APIUsage.Granularity.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.Granularity.IsNull() {
-					*granularity = shared.Granularity(tilesItem.Chart.Definition.Query.APIUsage.Granularity.ValueString())
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Granularity.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Granularity.IsNull() {
+					*granularity = shared.Granularity(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.Granularity.ValueString())
 				} else {
 					granularity = nil
 				}
 				var timeRange *shared.TimeRange
-				if tilesItem.Chart.Definition.Query.APIUsage.TimeRange != nil {
+				if r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange != nil {
 					var metricsRelativeTimeRangeDtoV2 *shared.MetricsRelativeTimeRangeDtoV2
-					if tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative != nil {
+					if r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative != nil {
 						tz := new(string)
-						if !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.IsNull() {
-							*tz = tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.ValueString()
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.IsNull() {
+							*tz = r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.Tz.ValueString()
 						} else {
 							tz = nil
 						}
-						typeVar1 := shared.MetricsRelativeTimeRangeDtoV2Type(tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.Type.ValueString())
+						typeVar1 := shared.MetricsRelativeTimeRangeDtoV2Type(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.Type.ValueString())
 						timeRange1 := new(shared.MetricsRelativeTimeRangeDtoV2TimeRange)
-						if !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.IsNull() {
-							*timeRange1 = shared.MetricsRelativeTimeRangeDtoV2TimeRange(tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.IsNull() {
+							*timeRange1 = shared.MetricsRelativeTimeRangeDtoV2TimeRange(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Relative.TimeRange.ValueString())
 						} else {
 							timeRange1 = nil
 						}
@@ -350,23 +350,23 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 						}
 					}
 					var metricsAbsoluteTimeRangeDtoV2 *shared.MetricsAbsoluteTimeRangeDtoV2
-					if tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute != nil {
+					if r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute != nil {
 						tz1 := new(string)
-						if !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.IsNull() {
-							*tz1 = tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.ValueString()
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.IsNull() {
+							*tz1 = r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Tz.ValueString()
 						} else {
 							tz1 = nil
 						}
-						typeVar2 := shared.MetricsAbsoluteTimeRangeDtoV2Type(tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Type.ValueString())
+						typeVar2 := shared.MetricsAbsoluteTimeRangeDtoV2Type(r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Type.ValueString())
 						start := new(time.Time)
-						if !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.IsNull() {
-							*start, _ = time.Parse(time.RFC3339Nano, tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.IsNull() {
+							*start, _ = time.Parse(time.RFC3339Nano, r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.Start.ValueString())
 						} else {
 							start = nil
 						}
 						end := new(time.Time)
-						if !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.IsUnknown() && !tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.IsNull() {
-							*end, _ = time.Parse(time.RFC3339Nano, tilesItem.Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.IsNull() {
+							*end, _ = time.Parse(time.RFC3339Nano, r.Definition.Tiles[tilesItem].Chart.Definition.Query.APIUsage.TimeRange.Absolute.End.ValueString())
 						} else {
 							end = nil
 						}
@@ -398,26 +398,26 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				}
 			}
 			var llmQuery *shared.LLMQuery
-			if tilesItem.Chart.Definition.Query.LlmUsage != nil {
-				datasource1 := shared.LLMQueryDatasource(tilesItem.Chart.Definition.Query.LlmUsage.Datasource.ValueString())
-				metrics1 := make([]shared.LLMMetrics, 0, len(tilesItem.Chart.Definition.Query.LlmUsage.Metrics))
-				for _, metricsItem1 := range tilesItem.Chart.Definition.Query.LlmUsage.Metrics {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage != nil {
+				datasource1 := shared.LLMQueryDatasource(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Datasource.ValueString())
+				metrics1 := make([]shared.LLMMetrics, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Metrics))
+				for _, metricsItem1 := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Metrics {
 					metrics1 = append(metrics1, shared.LLMMetrics(metricsItem1.ValueString()))
 				}
 				var dimensions1 []shared.LLMQueryDimensions
-				if tilesItem.Chart.Definition.Query.LlmUsage.Dimensions != nil {
-					dimensions1 = make([]shared.LLMQueryDimensions, 0, len(tilesItem.Chart.Definition.Query.LlmUsage.Dimensions))
-					for _, dimensionsItem1 := range tilesItem.Chart.Definition.Query.LlmUsage.Dimensions {
+				if r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Dimensions != nil {
+					dimensions1 = make([]shared.LLMQueryDimensions, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Dimensions))
+					for _, dimensionsItem1 := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Dimensions {
 						dimensions1 = append(dimensions1, shared.LLMQueryDimensions(dimensionsItem1.ValueString()))
 					}
 				}
-				filters1 := make([]shared.LLMFilters, 0, len(tilesItem.Chart.Definition.Query.LlmUsage.Filters))
-				for _, filtersItem1 := range tilesItem.Chart.Definition.Query.LlmUsage.Filters {
-					field1 := shared.LLMFiltersField(filtersItem1.Field.ValueString())
-					operator1 := shared.LLMFiltersOperator(filtersItem1.Operator.ValueString())
+				filters1 := make([]shared.LLMFilters, 0, len(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters))
+				for filtersIndex1 := range r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters {
+					field1 := shared.LLMFiltersField(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters[filtersIndex1].Field.ValueString())
+					operator1 := shared.LLMFiltersOperator(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters[filtersIndex1].Operator.ValueString())
 					var value1 interface{}
-					if !filtersItem1.Value.IsUnknown() && !filtersItem1.Value.IsNull() {
-						_ = json.Unmarshal([]byte(filtersItem1.Value.ValueString()), &value1)
+					if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters[filtersIndex1].Value.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters[filtersIndex1].Value.IsNull() {
+						_ = json.Unmarshal([]byte(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Filters[filtersIndex1].Value.ValueString()), &value1)
 					}
 					filters1 = append(filters1, shared.LLMFilters{
 						Field:    field1,
@@ -426,25 +426,25 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 					})
 				}
 				granularity1 := new(shared.Granularity)
-				if !tilesItem.Chart.Definition.Query.LlmUsage.Granularity.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.Granularity.IsNull() {
-					*granularity1 = shared.Granularity(tilesItem.Chart.Definition.Query.LlmUsage.Granularity.ValueString())
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Granularity.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Granularity.IsNull() {
+					*granularity1 = shared.Granularity(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.Granularity.ValueString())
 				} else {
 					granularity1 = nil
 				}
 				var timeRange2 *shared.TimeRange
-				if tilesItem.Chart.Definition.Query.LlmUsage.TimeRange != nil {
+				if r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange != nil {
 					var metricsRelativeTimeRangeDtoV21 *shared.MetricsRelativeTimeRangeDtoV2
-					if tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative != nil {
+					if r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative != nil {
 						tz2 := new(string)
-						if !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.IsNull() {
-							*tz2 = tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.ValueString()
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.IsNull() {
+							*tz2 = r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.Tz.ValueString()
 						} else {
 							tz2 = nil
 						}
-						typeVar3 := shared.MetricsRelativeTimeRangeDtoV2Type(tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.Type.ValueString())
+						typeVar3 := shared.MetricsRelativeTimeRangeDtoV2Type(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.Type.ValueString())
 						timeRange3 := new(shared.MetricsRelativeTimeRangeDtoV2TimeRange)
-						if !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.IsNull() {
-							*timeRange3 = shared.MetricsRelativeTimeRangeDtoV2TimeRange(tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.IsNull() {
+							*timeRange3 = shared.MetricsRelativeTimeRangeDtoV2TimeRange(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Relative.TimeRange.ValueString())
 						} else {
 							timeRange3 = nil
 						}
@@ -460,23 +460,23 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 						}
 					}
 					var metricsAbsoluteTimeRangeDtoV21 *shared.MetricsAbsoluteTimeRangeDtoV2
-					if tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute != nil {
+					if r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute != nil {
 						tz3 := new(string)
-						if !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.IsNull() {
-							*tz3 = tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.ValueString()
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.IsNull() {
+							*tz3 = r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Tz.ValueString()
 						} else {
 							tz3 = nil
 						}
-						typeVar4 := shared.MetricsAbsoluteTimeRangeDtoV2Type(tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Type.ValueString())
+						typeVar4 := shared.MetricsAbsoluteTimeRangeDtoV2Type(r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Type.ValueString())
 						start1 := new(time.Time)
-						if !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.IsNull() {
-							*start1, _ = time.Parse(time.RFC3339Nano, tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.IsNull() {
+							*start1, _ = time.Parse(time.RFC3339Nano, r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.Start.ValueString())
 						} else {
 							start1 = nil
 						}
 						end1 := new(time.Time)
-						if !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.IsUnknown() && !tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.IsNull() {
-							*end1, _ = time.Parse(time.RFC3339Nano, tilesItem.Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.ValueString())
+						if !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.IsNull() {
+							*end1, _ = time.Parse(time.RFC3339Nano, r.Definition.Tiles[tilesItem].Chart.Definition.Query.LlmUsage.TimeRange.Absolute.End.ValueString())
 						} else {
 							end1 = nil
 						}
@@ -509,14 +509,14 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 			}
 			var chart shared.Chart
 			var donutChart *shared.DonutChart
-			if tilesItem.Chart.Definition.Chart.Donut != nil {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Chart.Donut != nil {
 				chartTitle := new(string)
-				if !tilesItem.Chart.Definition.Chart.Donut.ChartTitle.IsUnknown() && !tilesItem.Chart.Definition.Chart.Donut.ChartTitle.IsNull() {
-					*chartTitle = tilesItem.Chart.Definition.Chart.Donut.ChartTitle.ValueString()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.Donut.ChartTitle.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.Donut.ChartTitle.IsNull() {
+					*chartTitle = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.Donut.ChartTitle.ValueString()
 				} else {
 					chartTitle = nil
 				}
-				typeVar5 := shared.DonutChartType(tilesItem.Chart.Definition.Chart.Donut.Type.ValueString())
+				typeVar5 := shared.DonutChartType(r.Definition.Tiles[tilesItem].Chart.Definition.Chart.Donut.Type.ValueString())
 				donutChart = &shared.DonutChart{
 					ChartTitle: chartTitle,
 					Type:       typeVar5,
@@ -528,17 +528,17 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				}
 			}
 			var timeseriesChart *shared.TimeseriesChart
-			if tilesItem.Chart.Definition.Chart.TimeseriesLine != nil {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine != nil {
 				chartTitle1 := new(string)
-				if !tilesItem.Chart.Definition.Chart.TimeseriesLine.ChartTitle.IsUnknown() && !tilesItem.Chart.Definition.Chart.TimeseriesLine.ChartTitle.IsNull() {
-					*chartTitle1 = tilesItem.Chart.Definition.Chart.TimeseriesLine.ChartTitle.ValueString()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.ChartTitle.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.ChartTitle.IsNull() {
+					*chartTitle1 = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.ChartTitle.ValueString()
 				} else {
 					chartTitle1 = nil
 				}
-				typeVar6 := shared.TimeseriesChartType(tilesItem.Chart.Definition.Chart.TimeseriesLine.Type.ValueString())
+				typeVar6 := shared.TimeseriesChartType(r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.Type.ValueString())
 				stacked := new(bool)
-				if !tilesItem.Chart.Definition.Chart.TimeseriesLine.Stacked.IsUnknown() && !tilesItem.Chart.Definition.Chart.TimeseriesLine.Stacked.IsNull() {
-					*stacked = tilesItem.Chart.Definition.Chart.TimeseriesLine.Stacked.ValueBool()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.Stacked.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.Stacked.IsNull() {
+					*stacked = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.TimeseriesLine.Stacked.ValueBool()
 				} else {
 					stacked = nil
 				}
@@ -554,17 +554,17 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				}
 			}
 			var barChart *shared.BarChart
-			if tilesItem.Chart.Definition.Chart.HorizontalBar != nil {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar != nil {
 				chartTitle2 := new(string)
-				if !tilesItem.Chart.Definition.Chart.HorizontalBar.ChartTitle.IsUnknown() && !tilesItem.Chart.Definition.Chart.HorizontalBar.ChartTitle.IsNull() {
-					*chartTitle2 = tilesItem.Chart.Definition.Chart.HorizontalBar.ChartTitle.ValueString()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.ChartTitle.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.ChartTitle.IsNull() {
+					*chartTitle2 = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.ChartTitle.ValueString()
 				} else {
 					chartTitle2 = nil
 				}
-				typeVar7 := shared.BarChartType(tilesItem.Chart.Definition.Chart.HorizontalBar.Type.ValueString())
+				typeVar7 := shared.BarChartType(r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.Type.ValueString())
 				stacked1 := new(bool)
-				if !tilesItem.Chart.Definition.Chart.HorizontalBar.Stacked.IsUnknown() && !tilesItem.Chart.Definition.Chart.HorizontalBar.Stacked.IsNull() {
-					*stacked1 = tilesItem.Chart.Definition.Chart.HorizontalBar.Stacked.ValueBool()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.Stacked.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.Stacked.IsNull() {
+					*stacked1 = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.HorizontalBar.Stacked.ValueBool()
 				} else {
 					stacked1 = nil
 				}
@@ -580,17 +580,17 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				}
 			}
 			var singleValueChart *shared.SingleValueChart
-			if tilesItem.Chart.Definition.Chart.SingleValue != nil {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue != nil {
 				chartTitle3 := new(string)
-				if !tilesItem.Chart.Definition.Chart.SingleValue.ChartTitle.IsUnknown() && !tilesItem.Chart.Definition.Chart.SingleValue.ChartTitle.IsNull() {
-					*chartTitle3 = tilesItem.Chart.Definition.Chart.SingleValue.ChartTitle.ValueString()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.ChartTitle.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.ChartTitle.IsNull() {
+					*chartTitle3 = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.ChartTitle.ValueString()
 				} else {
 					chartTitle3 = nil
 				}
-				typeVar8 := shared.SingleValueChartType(tilesItem.Chart.Definition.Chart.SingleValue.Type.ValueString())
+				typeVar8 := shared.SingleValueChartType(r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.Type.ValueString())
 				decimalPoints := new(float64)
-				if !tilesItem.Chart.Definition.Chart.SingleValue.DecimalPoints.IsUnknown() && !tilesItem.Chart.Definition.Chart.SingleValue.DecimalPoints.IsNull() {
-					*decimalPoints = tilesItem.Chart.Definition.Chart.SingleValue.DecimalPoints.ValueFloat64()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.DecimalPoints.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.DecimalPoints.IsNull() {
+					*decimalPoints = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.SingleValue.DecimalPoints.ValueFloat64()
 				} else {
 					decimalPoints = nil
 				}
@@ -606,14 +606,14 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 				}
 			}
 			var choroplethMapChart *shared.ChoroplethMapChart
-			if tilesItem.Chart.Definition.Chart.ChoroplethMap != nil {
+			if r.Definition.Tiles[tilesItem].Chart.Definition.Chart.ChoroplethMap != nil {
 				chartTitle4 := new(string)
-				if !tilesItem.Chart.Definition.Chart.ChoroplethMap.ChartTitle.IsUnknown() && !tilesItem.Chart.Definition.Chart.ChoroplethMap.ChartTitle.IsNull() {
-					*chartTitle4 = tilesItem.Chart.Definition.Chart.ChoroplethMap.ChartTitle.ValueString()
+				if !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.ChoroplethMap.ChartTitle.IsUnknown() && !r.Definition.Tiles[tilesItem].Chart.Definition.Chart.ChoroplethMap.ChartTitle.IsNull() {
+					*chartTitle4 = r.Definition.Tiles[tilesItem].Chart.Definition.Chart.ChoroplethMap.ChartTitle.ValueString()
 				} else {
 					chartTitle4 = nil
 				}
-				typeVar9 := shared.ChoroplethMapChartType(tilesItem.Chart.Definition.Chart.ChoroplethMap.Type.ValueString())
+				typeVar9 := shared.ChoroplethMapChartType(r.Definition.Tiles[tilesItem].Chart.Definition.Chart.ChoroplethMap.Type.ValueString())
 				choroplethMapChart = &shared.ChoroplethMapChart{
 					ChartTitle: chartTitle4,
 					Type:       typeVar9,
@@ -639,12 +639,12 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 		}
 	}
 	presetFilters := make([]shared.AllFilterItems, 0, len(r.Definition.PresetFilters))
-	for _, presetFiltersItem := range r.Definition.PresetFilters {
-		field2 := shared.AllFilterItemsField(presetFiltersItem.Field.ValueString())
-		operator2 := shared.AllFilterItemsOperator(presetFiltersItem.Operator.ValueString())
+	for presetFiltersIndex := range r.Definition.PresetFilters {
+		field2 := shared.AllFilterItemsField(r.Definition.PresetFilters[presetFiltersIndex].Field.ValueString())
+		operator2 := shared.AllFilterItemsOperator(r.Definition.PresetFilters[presetFiltersIndex].Operator.ValueString())
 		var value2 interface{}
-		if !presetFiltersItem.Value.IsUnknown() && !presetFiltersItem.Value.IsNull() {
-			_ = json.Unmarshal([]byte(presetFiltersItem.Value.ValueString()), &value2)
+		if !r.Definition.PresetFilters[presetFiltersIndex].Value.IsUnknown() && !r.Definition.PresetFilters[presetFiltersIndex].Value.IsNull() {
+			_ = json.Unmarshal([]byte(r.Definition.PresetFilters[presetFiltersIndex].Value.ValueString()), &value2)
 		}
 		presetFilters = append(presetFilters, shared.AllFilterItems{
 			Field:    field2,
@@ -657,10 +657,10 @@ func (r *DashboardResourceModel) ToSharedDashboardUpdateRequest(ctx context.Cont
 		PresetFilters: presetFilters,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgateway_resource.go
+++ b/internal/provider/eventgateway_resource.go
@@ -144,6 +144,13 @@ func (r *EventGatewayResource) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -318,7 +325,10 @@ func (r *EventGatewayResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgateway_resource_sdk.go
+++ b/internal/provider/eventgateway_resource_sdk.go
@@ -84,10 +84,10 @@ func (r *EventGatewayResourceModel) ToSharedCreateGatewayRequest(ctx context.Con
 	name = r.Name.ValueString()
 
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -111,10 +111,10 @@ func (r *EventGatewayResourceModel) ToSharedUpdateGatewayRequest(ctx context.Con
 		name = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewaybackendcluster_resource.go
+++ b/internal/provider/eventgatewaybackendcluster_resource.go
@@ -25,7 +25,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
 
@@ -71,7 +70,6 @@ func (r *EventGatewayBackendClusterResource) Schema(ctx context.Context, req res
 				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"anonymous": schema.SingleNestedAttribute{
-						Computed:    true,
 						Optional:    true,
 						Description: `Anonymous authentication scheme for the backend cluster.`,
 						Validators: []validator.Object{
@@ -82,7 +80,6 @@ func (r *EventGatewayBackendClusterResource) Schema(ctx context.Context, req res
 						},
 					},
 					"sasl_plain": schema.SingleNestedAttribute{
-						Computed: true,
 						Optional: true,
 						Attributes: map[string]schema.Attribute{
 							"password": schema.StringAttribute{
@@ -116,7 +113,6 @@ func (r *EventGatewayBackendClusterResource) Schema(ctx context.Context, req res
 						},
 					},
 					"sasl_scram": schema.SingleNestedAttribute{
-						Computed: true,
 						Optional: true,
 						Attributes: map[string]schema.Attribute{
 							"algorithm": schema.StringAttribute{
@@ -177,9 +173,6 @@ func (r *EventGatewayBackendClusterResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -268,9 +261,6 @@ func (r *EventGatewayBackendClusterResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -506,7 +496,10 @@ func (r *EventGatewayBackendClusterResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaybackendcluster_resource_sdk.go
+++ b/internal/provider/eventgatewaybackendcluster_resource_sdk.go
@@ -206,8 +206,8 @@ func (r *EventGatewayBackendClusterResourceModel) ToSharedCreateBackendClusterRe
 		insecureAllowAnonymousVirtualClusterAuth = nil
 	}
 	bootstrapServers := make([]string, 0, len(r.BootstrapServers))
-	for _, bootstrapServersItem := range r.BootstrapServers {
-		bootstrapServers = append(bootstrapServers, bootstrapServersItem.ValueString())
+	for bootstrapServersIndex := range r.BootstrapServers {
+		bootstrapServers = append(bootstrapServers, r.BootstrapServers[bootstrapServersIndex].ValueString())
 	}
 	var enabled bool
 	enabled = r.TLS.Enabled.ValueBool()
@@ -241,10 +241,10 @@ func (r *EventGatewayBackendClusterResourceModel) ToSharedCreateBackendClusterRe
 		metadataUpdateIntervalSeconds = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -337,8 +337,8 @@ func (r *EventGatewayBackendClusterResourceModel) ToSharedUpdateBackendClusterRe
 		insecureAllowAnonymousVirtualClusterAuth = nil
 	}
 	bootstrapServers := make([]string, 0, len(r.BootstrapServers))
-	for _, bootstrapServersItem := range r.BootstrapServers {
-		bootstrapServers = append(bootstrapServers, bootstrapServersItem.ValueString())
+	for bootstrapServersIndex := range r.BootstrapServers {
+		bootstrapServers = append(bootstrapServers, r.BootstrapServers[bootstrapServersIndex].ValueString())
 	}
 	var enabled bool
 	enabled = r.TLS.Enabled.ValueBool()
@@ -372,10 +372,10 @@ func (r *EventGatewayBackendClusterResourceModel) ToSharedUpdateBackendClusterRe
 		metadataUpdateIntervalSeconds = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayclusterpolicyacls_resource.go
+++ b/internal/provider/eventgatewayclusterpolicyacls_resource.go
@@ -19,7 +19,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -148,9 +147,6 @@ func (r *EventGatewayClusterPolicyAclsResource) Schema(ctx context.Context, req 
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -198,9 +194,6 @@ func (r *EventGatewayClusterPolicyAclsResource) Schema(ctx context.Context, req 
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -514,7 +507,10 @@ func (r *EventGatewayClusterPolicyAclsResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayclusterpolicyacls_resource_sdk.go
+++ b/internal/provider/eventgatewayclusterpolicyacls_resource_sdk.go
@@ -160,20 +160,20 @@ func (r *EventGatewayClusterPolicyAclsResourceModel) ToSharedEventGatewayACLsPol
 		condition = nil
 	}
 	rules := make([]shared.EventGatewayACLRule, 0, len(r.Config.Rules))
-	for _, rulesItem := range r.Config.Rules {
-		resourceType := shared.ResourceType(rulesItem.ResourceType.ValueString())
-		action := shared.Action(rulesItem.Action.ValueString())
-		operationsVar := make([]shared.EventGatewayACLOperation, 0, len(rulesItem.Operations))
-		for _, operationsItem := range rulesItem.Operations {
-			name1 := shared.Name(operationsItem.Name.ValueString())
+	for rulesIndex := range r.Config.Rules {
+		resourceType := shared.ResourceType(r.Config.Rules[rulesIndex].ResourceType.ValueString())
+		action := shared.Action(r.Config.Rules[rulesIndex].Action.ValueString())
+		operationsVar := make([]shared.EventGatewayACLOperation, 0, len(r.Config.Rules[rulesIndex].Operations))
+		for operationsIndex := range r.Config.Rules[rulesIndex].Operations {
+			name1 := shared.Name(r.Config.Rules[rulesIndex].Operations[operationsIndex].Name.ValueString())
 			operationsVar = append(operationsVar, shared.EventGatewayACLOperation{
 				Name: name1,
 			})
 		}
-		resourceNames := make([]shared.EventGatewayACLResourceName, 0, len(rulesItem.ResourceNames))
-		for _, resourceNamesItem := range rulesItem.ResourceNames {
+		resourceNames := make([]shared.EventGatewayACLResourceName, 0, len(r.Config.Rules[rulesIndex].ResourceNames))
+		for resourceNamesIndex := range r.Config.Rules[rulesIndex].ResourceNames {
 			var match string
-			match = resourceNamesItem.Match.ValueString()
+			match = r.Config.Rules[rulesIndex].ResourceNames[resourceNamesIndex].Match.ValueString()
 
 			resourceNames = append(resourceNames, shared.EventGatewayACLResourceName{
 				Match: match,
@@ -190,10 +190,10 @@ func (r *EventGatewayClusterPolicyAclsResourceModel) ToSharedEventGatewayACLsPol
 		Rules: rules,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayconsumepolicydecrypt_resource.go
+++ b/internal/provider/eventgatewayconsumepolicydecrypt_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -134,9 +133,6 @@ func (r *EventGatewayConsumePolicyDecryptResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -184,9 +180,6 @@ func (r *EventGatewayConsumePolicyDecryptResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -500,7 +493,10 @@ func (r *EventGatewayConsumePolicyDecryptResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayconsumepolicydecrypt_resource_sdk.go
+++ b/internal/provider/eventgatewayconsumepolicydecrypt_resource_sdk.go
@@ -163,14 +163,14 @@ func (r *EventGatewayConsumePolicyDecryptResourceModel) ToSharedEventGatewayDecr
 	}
 	failureMode := shared.EncryptionFailureMode(r.Config.FailureMode.ValueString())
 	keySources := make([]shared.EventGatewayKeySource, 0, len(r.Config.KeySources))
-	for _, keySourcesItem := range r.Config.KeySources {
-		if keySourcesItem.Aws != nil {
+	for keySourcesItem := range r.Config.KeySources {
+		if r.Config.KeySources[keySourcesItem].Aws != nil {
 			eventGatewayAWSKeySource := shared.EventGatewayAWSKeySource{}
 			keySources = append(keySources, shared.EventGatewayKeySource{
 				EventGatewayAWSKeySource: &eventGatewayAWSKeySource,
 			})
 		}
-		if keySourcesItem.Static != nil {
+		if r.Config.KeySources[keySourcesItem].Static != nil {
 			eventGatewayStaticKeySource := shared.EventGatewayStaticKeySource{}
 			keySources = append(keySources, shared.EventGatewayKeySource{
 				EventGatewayStaticKeySource: &eventGatewayStaticKeySource,
@@ -187,10 +187,10 @@ func (r *EventGatewayConsumePolicyDecryptResourceModel) ToSharedEventGatewayDecr
 		PartOfRecord: partOfRecord,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayconsumepolicymodifyheaders_resource.go
+++ b/internal/provider/eventgatewayconsumepolicymodifyheaders_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -130,9 +129,6 @@ func (r *EventGatewayConsumePolicyModifyHeadersResource) Schema(ctx context.Cont
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -183,9 +179,6 @@ func (r *EventGatewayConsumePolicyModifyHeadersResource) Schema(ctx context.Cont
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -499,7 +492,10 @@ func (r *EventGatewayConsumePolicyModifyHeadersResource) Delete(ctx context.Cont
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayconsumepolicymodifyheaders_resource_sdk.go
+++ b/internal/provider/eventgatewayconsumepolicymodifyheaders_resource_sdk.go
@@ -162,10 +162,10 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 	var actions []shared.EventGatewayModifyHeaderAction
 	if r.Config.Actions != nil {
 		actions = make([]shared.EventGatewayModifyHeaderAction, 0, len(r.Config.Actions))
-		for _, actionsItem := range r.Config.Actions {
-			if actionsItem.Remove != nil {
+		for actionsItem := range r.Config.Actions {
+			if r.Config.Actions[actionsItem].Remove != nil {
 				var key string
-				key = actionsItem.Remove.Key.ValueString()
+				key = r.Config.Actions[actionsItem].Remove.Key.ValueString()
 
 				eventGatewayModifyHeaderRemoveAction := shared.EventGatewayModifyHeaderRemoveAction{
 					Key: key,
@@ -174,12 +174,12 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 					EventGatewayModifyHeaderRemoveAction: &eventGatewayModifyHeaderRemoveAction,
 				})
 			}
-			if actionsItem.Set != nil {
+			if r.Config.Actions[actionsItem].Set != nil {
 				var key1 string
-				key1 = actionsItem.Set.Key.ValueString()
+				key1 = r.Config.Actions[actionsItem].Set.Key.ValueString()
 
 				var value string
-				value = actionsItem.Set.Value.ValueString()
+				value = r.Config.Actions[actionsItem].Set.Value.ValueString()
 
 				eventGatewayModifyHeaderSetAction := shared.EventGatewayModifyHeaderSetAction{
 					Key:   key1,
@@ -195,10 +195,10 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 		Actions: actions,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -246,10 +246,10 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 	var actions []shared.EventGatewayModifyHeaderAction
 	if r.Config.Actions != nil {
 		actions = make([]shared.EventGatewayModifyHeaderAction, 0, len(r.Config.Actions))
-		for _, actionsItem := range r.Config.Actions {
-			if actionsItem.Remove != nil {
+		for actionsItem := range r.Config.Actions {
+			if r.Config.Actions[actionsItem].Remove != nil {
 				var key string
-				key = actionsItem.Remove.Key.ValueString()
+				key = r.Config.Actions[actionsItem].Remove.Key.ValueString()
 
 				eventGatewayModifyHeaderRemoveAction := shared.EventGatewayModifyHeaderRemoveAction{
 					Key: key,
@@ -258,12 +258,12 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 					EventGatewayModifyHeaderRemoveAction: &eventGatewayModifyHeaderRemoveAction,
 				})
 			}
-			if actionsItem.Set != nil {
+			if r.Config.Actions[actionsItem].Set != nil {
 				var key1 string
-				key1 = actionsItem.Set.Key.ValueString()
+				key1 = r.Config.Actions[actionsItem].Set.Key.ValueString()
 
 				var value string
-				value = actionsItem.Set.Value.ValueString()
+				value = r.Config.Actions[actionsItem].Set.Value.ValueString()
 
 				eventGatewayModifyHeaderSetAction := shared.EventGatewayModifyHeaderSetAction{
 					Key:   key1,
@@ -279,10 +279,10 @@ func (r *EventGatewayConsumePolicyModifyHeadersResourceModel) ToSharedEventGatew
 		Actions: actions,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayconsumepolicyschemavalidation_resource.go
+++ b/internal/provider/eventgatewayconsumepolicyschemavalidation_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -181,9 +180,6 @@ func (r *EventGatewayConsumePolicySchemaValidationResource) Schema(ctx context.C
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -231,9 +227,6 @@ func (r *EventGatewayConsumePolicySchemaValidationResource) Schema(ctx context.C
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -547,7 +540,10 @@ func (r *EventGatewayConsumePolicySchemaValidationResource) Delete(ctx context.C
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayconsumepolicyschemavalidation_resource_sdk.go
+++ b/internal/provider/eventgatewayconsumepolicyschemavalidation_resource_sdk.go
@@ -223,10 +223,10 @@ func (r *EventGatewayConsumePolicySchemaValidationResourceModel) ToSharedEventGa
 		}
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayconsumepolicyskiprecord_resource.go
+++ b/internal/provider/eventgatewayconsumepolicyskiprecord_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -81,9 +80,6 @@ func (r *EventGatewayConsumePolicySkipRecordResource) Schema(ctx context.Context
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -134,9 +130,6 @@ func (r *EventGatewayConsumePolicySkipRecordResource) Schema(ctx context.Context
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -376,7 +369,10 @@ func (r *EventGatewayConsumePolicySkipRecordResource) Delete(ctx context.Context
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayconsumepolicyskiprecord_resource_sdk.go
+++ b/internal/provider/eventgatewayconsumepolicyskiprecord_resource_sdk.go
@@ -158,10 +158,10 @@ func (r *EventGatewayConsumePolicySkipRecordResourceModel) ToSharedEventGatewayS
 		condition = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -206,10 +206,10 @@ func (r *EventGatewayConsumePolicySkipRecordResourceModel) ToSharedEventGatewayS
 		condition = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewaydataplanecertificate_resource.go
+++ b/internal/provider/eventgatewaydataplanecertificate_resource.go
@@ -18,7 +18,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -65,9 +64,6 @@ func (r *EventGatewayDataPlaneCertificateResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -146,9 +142,6 @@ func (r *EventGatewayDataPlaneCertificateResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -384,7 +377,10 @@ func (r *EventGatewayDataPlaneCertificateResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaylistener_resource.go
+++ b/internal/provider/eventgatewaylistener_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -77,9 +76,6 @@ func (r *EventGatewayListenerResource) Schema(ctx context.Context, req resource.
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -133,9 +129,6 @@ func (r *EventGatewayListenerResource) Schema(ctx context.Context, req resource.
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -371,7 +364,10 @@ func (r *EventGatewayListenerResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaylistener_resource_sdk.go
+++ b/internal/provider/eventgatewaylistener_resource_sdk.go
@@ -132,18 +132,18 @@ func (r *EventGatewayListenerResourceModel) ToSharedCreateEventGatewayListenerRe
 		description = nil
 	}
 	addresses := make([]string, 0, len(r.Addresses))
-	for _, addressesItem := range r.Addresses {
-		addresses = append(addresses, addressesItem.ValueString())
+	for addressesIndex := range r.Addresses {
+		addresses = append(addresses, r.Addresses[addressesIndex].ValueString())
 	}
 	ports := make([]string, 0, len(r.Ports))
-	for _, portsItem := range r.Ports {
-		ports = append(ports, portsItem.ValueString())
+	for portsIndex := range r.Ports {
+		ports = append(ports, r.Ports[portsIndex].ValueString())
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -173,18 +173,18 @@ func (r *EventGatewayListenerResourceModel) ToSharedUpdateEventGatewayListenerRe
 		description = nil
 	}
 	addresses := make([]string, 0, len(r.Addresses))
-	for _, addressesItem := range r.Addresses {
-		addresses = append(addresses, addressesItem.ValueString())
+	for addressesIndex := range r.Addresses {
+		addresses = append(addresses, r.Addresses[addressesIndex].ValueString())
 	}
 	ports := make([]string, 0, len(r.Ports))
-	for _, portsItem := range r.Ports {
-		ports = append(ports, portsItem.ValueString())
+	for portsIndex := range r.Ports {
+		ports = append(ports, r.Ports[portsIndex].ValueString())
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewaylistenerpolicyforwardtovirtualcluster_resource.go
+++ b/internal/provider/eventgatewaylistenerpolicyforwardtovirtualcluster_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	"regexp"
 )
 
@@ -208,9 +207,6 @@ func (r *EventGatewayListenerPolicyForwardToVirtualClusterResource) Schema(ctx c
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -262,9 +258,6 @@ func (r *EventGatewayListenerPolicyForwardToVirtualClusterResource) Schema(ctx c
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -500,7 +493,10 @@ func (r *EventGatewayListenerPolicyForwardToVirtualClusterResource) Delete(ctx c
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaylistenerpolicyforwardtovirtualcluster_resource_sdk.go
+++ b/internal/provider/eventgatewaylistenerpolicyforwardtovirtualcluster_resource_sdk.go
@@ -234,10 +234,10 @@ func (r *EventGatewayListenerPolicyForwardToVirtualClusterResourceModel) ToShare
 		}
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewaylistenerpolicytlsserver_resource.go
+++ b/internal/provider/eventgatewaylistenerpolicytlsserver_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -131,9 +130,6 @@ func (r *EventGatewayListenerPolicyTLSServerResource) Schema(ctx context.Context
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -185,9 +181,6 @@ func (r *EventGatewayListenerPolicyTLSServerResource) Schema(ctx context.Context
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -497,7 +490,10 @@ func (r *EventGatewayListenerPolicyTLSServerResource) Delete(ctx context.Context
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaylistenerpolicytlsserver_resource_sdk.go
+++ b/internal/provider/eventgatewaylistenerpolicytlsserver_resource_sdk.go
@@ -155,12 +155,12 @@ func (r *EventGatewayListenerPolicyTLSServerResourceModel) ToSharedEventGatewayT
 		enabled = nil
 	}
 	certificates := make([]shared.TLSCertificate, 0, len(r.Config.Certificates))
-	for _, certificatesItem := range r.Config.Certificates {
+	for certificatesIndex := range r.Config.Certificates {
 		var certificate string
-		certificate = certificatesItem.Certificate.ValueString()
+		certificate = r.Config.Certificates[certificatesIndex].Certificate.ValueString()
 
 		var key string
-		key = certificatesItem.Key.ValueString()
+		key = r.Config.Certificates[certificatesIndex].Key.ValueString()
 
 		certificates = append(certificates, shared.TLSCertificate{
 			Certificate: certificate,
@@ -198,10 +198,10 @@ func (r *EventGatewayListenerPolicyTLSServerResourceModel) ToSharedEventGatewayT
 		AllowPlaintext: allowPlaintext,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -240,13 +240,13 @@ func (r *EventGatewayListenerPolicyTLSServerResourceModel) ToSharedEventGatewayT
 		enabled = nil
 	}
 	certificates := make([]shared.TLSCertificateSensitiveDataAware, 0, len(r.Config.Certificates))
-	for _, certificatesItem := range r.Config.Certificates {
+	for certificatesIndex := range r.Config.Certificates {
 		var certificate string
-		certificate = certificatesItem.Certificate.ValueString()
+		certificate = r.Config.Certificates[certificatesIndex].Certificate.ValueString()
 
 		key := new(string)
-		if !certificatesItem.Key.IsUnknown() && !certificatesItem.Key.IsNull() {
-			*key = certificatesItem.Key.ValueString()
+		if !r.Config.Certificates[certificatesIndex].Key.IsUnknown() && !r.Config.Certificates[certificatesIndex].Key.IsNull() {
+			*key = r.Config.Certificates[certificatesIndex].Key.ValueString()
 		} else {
 			key = nil
 		}
@@ -286,10 +286,10 @@ func (r *EventGatewayListenerPolicyTLSServerResourceModel) ToSharedEventGatewayT
 		AllowPlaintext: allowPlaintext,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayproducepolicyencrypt_resource.go
+++ b/internal/provider/eventgatewayproducepolicyencrypt_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	"regexp"
 )
 
@@ -178,9 +177,6 @@ func (r *EventGatewayProducePolicyEncryptResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -228,9 +224,6 @@ func (r *EventGatewayProducePolicyEncryptResource) Schema(ctx context.Context, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -544,7 +537,10 @@ func (r *EventGatewayProducePolicyEncryptResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayproducepolicyencrypt_resource_sdk.go
+++ b/internal/provider/eventgatewayproducepolicyencrypt_resource_sdk.go
@@ -227,10 +227,10 @@ func (r *EventGatewayProducePolicyEncryptResourceModel) ToSharedEventGatewayEncr
 		EncryptionKey: encryptionKey,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayproducepolicymodifyheaders_resource.go
+++ b/internal/provider/eventgatewayproducepolicymodifyheaders_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -130,9 +129,6 @@ func (r *EventGatewayProducePolicyModifyHeadersResource) Schema(ctx context.Cont
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -183,9 +179,6 @@ func (r *EventGatewayProducePolicyModifyHeadersResource) Schema(ctx context.Cont
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -499,7 +492,10 @@ func (r *EventGatewayProducePolicyModifyHeadersResource) Delete(ctx context.Cont
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayproducepolicymodifyheaders_resource_sdk.go
+++ b/internal/provider/eventgatewayproducepolicymodifyheaders_resource_sdk.go
@@ -162,10 +162,10 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 	var actions []shared.EventGatewayModifyHeaderAction
 	if r.Config.Actions != nil {
 		actions = make([]shared.EventGatewayModifyHeaderAction, 0, len(r.Config.Actions))
-		for _, actionsItem := range r.Config.Actions {
-			if actionsItem.Remove != nil {
+		for actionsItem := range r.Config.Actions {
+			if r.Config.Actions[actionsItem].Remove != nil {
 				var key string
-				key = actionsItem.Remove.Key.ValueString()
+				key = r.Config.Actions[actionsItem].Remove.Key.ValueString()
 
 				eventGatewayModifyHeaderRemoveAction := shared.EventGatewayModifyHeaderRemoveAction{
 					Key: key,
@@ -174,12 +174,12 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 					EventGatewayModifyHeaderRemoveAction: &eventGatewayModifyHeaderRemoveAction,
 				})
 			}
-			if actionsItem.Set != nil {
+			if r.Config.Actions[actionsItem].Set != nil {
 				var key1 string
-				key1 = actionsItem.Set.Key.ValueString()
+				key1 = r.Config.Actions[actionsItem].Set.Key.ValueString()
 
 				var value string
-				value = actionsItem.Set.Value.ValueString()
+				value = r.Config.Actions[actionsItem].Set.Value.ValueString()
 
 				eventGatewayModifyHeaderSetAction := shared.EventGatewayModifyHeaderSetAction{
 					Key:   key1,
@@ -195,10 +195,10 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 		Actions: actions,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -246,10 +246,10 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 	var actions []shared.EventGatewayModifyHeaderAction
 	if r.Config.Actions != nil {
 		actions = make([]shared.EventGatewayModifyHeaderAction, 0, len(r.Config.Actions))
-		for _, actionsItem := range r.Config.Actions {
-			if actionsItem.Remove != nil {
+		for actionsItem := range r.Config.Actions {
+			if r.Config.Actions[actionsItem].Remove != nil {
 				var key string
-				key = actionsItem.Remove.Key.ValueString()
+				key = r.Config.Actions[actionsItem].Remove.Key.ValueString()
 
 				eventGatewayModifyHeaderRemoveAction := shared.EventGatewayModifyHeaderRemoveAction{
 					Key: key,
@@ -258,12 +258,12 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 					EventGatewayModifyHeaderRemoveAction: &eventGatewayModifyHeaderRemoveAction,
 				})
 			}
-			if actionsItem.Set != nil {
+			if r.Config.Actions[actionsItem].Set != nil {
 				var key1 string
-				key1 = actionsItem.Set.Key.ValueString()
+				key1 = r.Config.Actions[actionsItem].Set.Key.ValueString()
 
 				var value string
-				value = actionsItem.Set.Value.ValueString()
+				value = r.Config.Actions[actionsItem].Set.Value.ValueString()
 
 				eventGatewayModifyHeaderSetAction := shared.EventGatewayModifyHeaderSetAction{
 					Key:   key1,
@@ -279,10 +279,10 @@ func (r *EventGatewayProducePolicyModifyHeadersResourceModel) ToSharedEventGatew
 		Actions: actions,
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayproducepolicyschemavalidation_resource.go
+++ b/internal/provider/eventgatewayproducepolicyschemavalidation_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -238,9 +237,6 @@ func (r *EventGatewayProducePolicySchemaValidationResource) Schema(ctx context.C
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -288,9 +284,6 @@ func (r *EventGatewayProducePolicySchemaValidationResource) Schema(ctx context.C
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"virtual_cluster_id": schema.StringAttribute{
 				Required:    true,
@@ -530,7 +523,10 @@ func (r *EventGatewayProducePolicySchemaValidationResource) Delete(ctx context.C
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayproducepolicyschemavalidation_resource_sdk.go
+++ b/internal/provider/eventgatewayproducepolicyschemavalidation_resource_sdk.go
@@ -271,10 +271,10 @@ func (r *EventGatewayProducePolicySchemaValidationResourceModel) ToSharedEventGa
 		}
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayschemaregistry_resource.go
+++ b/internal/provider/eventgatewayschemaregistry_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -151,16 +150,10 @@ func (r *EventGatewaySchemaRegistryResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Description: `A human-readable description of the virtual cluster.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthAtMost(512),
-				},
 			},
 			"gateway_id": schema.StringAttribute{
 				Required:    true,
@@ -180,9 +173,6 @@ func (r *EventGatewaySchemaRegistryResource) Schema(ctx context.Context, req res
 			"name": schema.StringAttribute{
 				Computed:    true,
 				Description: `The unique name of the schema registry.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthBetween(1, 255),
-				},
 			},
 			"type": schema.StringAttribute{
 				Computed:    true,
@@ -194,9 +184,6 @@ func (r *EventGatewaySchemaRegistryResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -432,7 +419,10 @@ func (r *EventGatewaySchemaRegistryResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayschemaregistry_resource_sdk.go
+++ b/internal/provider/eventgatewayschemaregistry_resource_sdk.go
@@ -171,10 +171,10 @@ func (r *EventGatewaySchemaRegistryResourceModel) ToSharedSchemaRegistryCreate(c
 			Authentication: authentication,
 		}
 		labels := make(map[string]*string)
-		for labelsKey, labelsValue := range r.Confluent.Labels {
+		for labelsKey := range r.Confluent.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Confluent.Labels[labelsKey].IsUnknown() && !r.Confluent.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Confluent.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -252,10 +252,10 @@ func (r *EventGatewaySchemaRegistryResourceModel) ToSharedSchemaRegistryUpdate(c
 			Authentication: authentication,
 		}
 		labels := make(map[string]*string)
-		for labelsKey, labelsValue := range r.Confluent.Labels {
+		for labelsKey := range r.Confluent.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Confluent.Labels[labelsKey].IsUnknown() && !r.Confluent.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Confluent.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/eventgatewaystatickey_resource.go
+++ b/internal/provider/eventgatewaystatickey_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_mapplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/mapplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -63,9 +62,6 @@ func (r *EventGatewayStaticKeyResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -118,9 +114,6 @@ func (r *EventGatewayStaticKeyResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"value": schema.StringAttribute{
 				Required: true,
@@ -331,7 +324,10 @@ func (r *EventGatewayStaticKeyResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewaystatickey_resource_sdk.go
+++ b/internal/provider/eventgatewaystatickey_resource_sdk.go
@@ -100,10 +100,10 @@ func (r *EventGatewayStaticKeyResourceModel) ToSharedEventGatewayStaticKeyCreate
 		description = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/eventgatewayvault_resource.go
+++ b/internal/provider/eventgatewayvault_resource.go
@@ -19,7 +19,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 	"regexp"
@@ -60,12 +59,8 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Description: `A human-readable description of the vault.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthAtMost(512),
-				},
 			},
 			"env": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"config": schema.SingleNestedAttribute{
@@ -92,9 +87,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"description": schema.StringAttribute{
 						Optional:    true,
@@ -131,9 +123,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 				},
 				Description: `An environment vault.`,
@@ -152,7 +141,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 				Description: `The unique identifier of the vault.`,
 			},
 			"konnect": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"created_at": schema.StringAttribute{
@@ -161,9 +149,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"description": schema.StringAttribute{
 						Optional:    true,
@@ -200,9 +185,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 				},
 				Description: `A konnect vault.`,
@@ -215,10 +197,6 @@ func (r *EventGatewayVaultResource) Schema(ctx context.Context, req resource.Sch
 			"name": schema.StringAttribute{
 				Computed:    true,
 				Description: `The name of the vault.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthBetween(1, 255),
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[\p{L}\p{N}][\p{L}\p{N} _\-\.']*[\p{L}\p{N}]$`), "must match pattern "+regexp.MustCompile(`^[\p{L}\p{N}][\p{L}\p{N} _\-\.']*[\p{L}\p{N}]$`).String()),
-				},
 			},
 		},
 	}
@@ -454,7 +432,10 @@ func (r *EventGatewayVaultResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayvault_resource_sdk.go
+++ b/internal/provider/eventgatewayvault_resource_sdk.go
@@ -152,10 +152,10 @@ func (r *EventGatewayVaultResourceModel) ToSharedEventGatewayModifyVault(ctx con
 			description = nil
 		}
 		labels := make(map[string]*string)
-		for labelsKey, labelsValue := range r.Env.Labels {
+		for labelsKey := range r.Env.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Env.Labels[labelsKey].IsUnknown() && !r.Env.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Env.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -191,10 +191,10 @@ func (r *EventGatewayVaultResourceModel) ToSharedEventGatewayModifyVault(ctx con
 			description1 = nil
 		}
 		labels1 := make(map[string]*string)
-		for labelsKey1, labelsValue1 := range r.Konnect.Labels {
+		for labelsKey1 := range r.Konnect.Labels {
 			labelsInst1 := new(string)
-			if !labelsValue1.IsUnknown() && !labelsValue1.IsNull() {
-				*labelsInst1 = labelsValue1.ValueString()
+			if !r.Konnect.Labels[labelsKey1].IsUnknown() && !r.Konnect.Labels[labelsKey1].IsNull() {
+				*labelsInst1 = r.Konnect.Labels[labelsKey1].ValueString()
 			} else {
 				labelsInst1 = nil
 			}

--- a/internal/provider/eventgatewayvirtualcluster_resource.go
+++ b/internal/provider/eventgatewayvirtualcluster_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 	"regexp"
@@ -89,7 +88,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 					},
 					Attributes: map[string]schema.Attribute{
 						"anonymous": schema.SingleNestedAttribute{
-							Computed: true,
 							Optional: true,
 							Validators: []validator.Object{
 								objectvalidator.ConflictsWith(path.Expressions{
@@ -100,7 +98,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 							},
 						},
 						"oauth_bearer": schema.SingleNestedAttribute{
-							Computed: true,
 							Optional: true,
 							Attributes: map[string]schema.Attribute{
 								"claims_mapping": schema.SingleNestedAttribute{
@@ -224,7 +221,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 							},
 						},
 						"sasl_plain": schema.SingleNestedAttribute{
-							Computed: true,
 							Optional: true,
 							Attributes: map[string]schema.Attribute{
 								"mediation": schema.StringAttribute{
@@ -285,7 +281,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 							},
 						},
 						"sasl_scram": schema.SingleNestedAttribute{
-							Computed: true,
 							Optional: true,
 							Attributes: map[string]schema.Attribute{
 								"algorithm": schema.StringAttribute{
@@ -326,9 +321,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -348,9 +340,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 					"name": schema.StringAttribute{
 						Computed:    true,
 						Description: `The unique name of the backend cluster.`,
-						Validators: []validator.String{
-							stringvalidator.UTF8LengthBetween(1, 255),
-						},
 					},
 				},
 				MarkdownDescription: `The backend cluster associated with the virtual cluster.` + "\n" +
@@ -408,7 +397,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 									},
 									Attributes: map[string]schema.Attribute{
 										"exact_list": schema.SingleNestedAttribute{
-											Computed: true,
 											Optional: true,
 											Attributes: map[string]schema.Attribute{
 												"exact_list": schema.ListNestedAttribute{
@@ -441,7 +429,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 											},
 										},
 										"glob": schema.SingleNestedAttribute{
-											Computed: true,
 											Optional: true,
 											Attributes: map[string]schema.Attribute{
 												"glob": schema.StringAttribute{
@@ -474,7 +461,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 									},
 									Attributes: map[string]schema.Attribute{
 										"exact_list": schema.SingleNestedAttribute{
-											Computed: true,
 											Optional: true,
 											Attributes: map[string]schema.Attribute{
 												"conflict": schema.StringAttribute{
@@ -523,7 +509,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 											},
 										},
 										"glob": schema.SingleNestedAttribute{
-											Computed: true,
 											Optional: true,
 											Attributes: map[string]schema.Attribute{
 												"conflict": schema.StringAttribute{
@@ -601,9 +586,6 @@ func (r *EventGatewayVirtualClusterResource) Schema(ctx context.Context, req res
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -839,7 +821,10 @@ func (r *EventGatewayVirtualClusterResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/eventgatewayvirtualcluster_resource_sdk.go
+++ b/internal/provider/eventgatewayvirtualcluster_resource_sdk.go
@@ -279,24 +279,24 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 		ID: id,
 	}
 	authentication := make([]shared.VirtualClusterAuthenticationScheme, 0, len(r.Authentication))
-	for _, authenticationItem := range r.Authentication {
-		if authenticationItem.Anonymous != nil {
+	for authenticationItem := range r.Authentication {
+		if r.Authentication[authenticationItem].Anonymous != nil {
 			virtualClusterAuthenticationAnonymous := shared.VirtualClusterAuthenticationAnonymous{}
 			authentication = append(authentication, shared.VirtualClusterAuthenticationScheme{
 				VirtualClusterAuthenticationAnonymous: &virtualClusterAuthenticationAnonymous,
 			})
 		}
-		if authenticationItem.SaslPlain != nil {
-			mediation := shared.Mediation(authenticationItem.SaslPlain.Mediation.ValueString())
+		if r.Authentication[authenticationItem].SaslPlain != nil {
+			mediation := shared.Mediation(r.Authentication[authenticationItem].SaslPlain.Mediation.ValueString())
 			var principals []shared.VirtualClusterAuthenticationPrincipal
-			if authenticationItem.SaslPlain.Principals != nil {
-				principals = make([]shared.VirtualClusterAuthenticationPrincipal, 0, len(authenticationItem.SaslPlain.Principals))
-				for _, principalsItem := range authenticationItem.SaslPlain.Principals {
+			if r.Authentication[authenticationItem].SaslPlain.Principals != nil {
+				principals = make([]shared.VirtualClusterAuthenticationPrincipal, 0, len(r.Authentication[authenticationItem].SaslPlain.Principals))
+				for principalsIndex := range r.Authentication[authenticationItem].SaslPlain.Principals {
 					var username string
-					username = principalsItem.Username.ValueString()
+					username = r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Username.ValueString()
 
 					var password string
-					password = principalsItem.Password.ValueString()
+					password = r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Password.ValueString()
 
 					principals = append(principals, shared.VirtualClusterAuthenticationPrincipal{
 						Username: username,
@@ -312,8 +312,8 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 				VirtualClusterAuthenticationSaslPlain: &virtualClusterAuthenticationSaslPlain,
 			})
 		}
-		if authenticationItem.SaslScram != nil {
-			algorithm := shared.VirtualClusterAuthenticationSaslScramAlgorithm(authenticationItem.SaslScram.Algorithm.ValueString())
+		if r.Authentication[authenticationItem].SaslScram != nil {
+			algorithm := shared.VirtualClusterAuthenticationSaslScramAlgorithm(r.Authentication[authenticationItem].SaslScram.Algorithm.ValueString())
 			virtualClusterAuthenticationSaslScram := shared.VirtualClusterAuthenticationSaslScram{
 				Algorithm: algorithm,
 			}
@@ -321,19 +321,19 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 				VirtualClusterAuthenticationSaslScram: &virtualClusterAuthenticationSaslScram,
 			})
 		}
-		if authenticationItem.OauthBearer != nil {
-			mediation1 := shared.VirtualClusterAuthenticationOauthBearerMediation(authenticationItem.OauthBearer.Mediation.ValueString())
+		if r.Authentication[authenticationItem].OauthBearer != nil {
+			mediation1 := shared.VirtualClusterAuthenticationOauthBearerMediation(r.Authentication[authenticationItem].OauthBearer.Mediation.ValueString())
 			var claimsMapping *shared.VirtualClusterAuthenticationClaimsMapping
-			if authenticationItem.OauthBearer.ClaimsMapping != nil {
+			if r.Authentication[authenticationItem].OauthBearer.ClaimsMapping != nil {
 				sub := new(string)
-				if !authenticationItem.OauthBearer.ClaimsMapping.Sub.IsUnknown() && !authenticationItem.OauthBearer.ClaimsMapping.Sub.IsNull() {
-					*sub = authenticationItem.OauthBearer.ClaimsMapping.Sub.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.IsNull() {
+					*sub = r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.ValueString()
 				} else {
 					sub = nil
 				}
 				scope := new(string)
-				if !authenticationItem.OauthBearer.ClaimsMapping.Scope.IsUnknown() && !authenticationItem.OauthBearer.ClaimsMapping.Scope.IsNull() {
-					*scope = authenticationItem.OauthBearer.ClaimsMapping.Scope.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.IsNull() {
+					*scope = r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.ValueString()
 				} else {
 					scope = nil
 				}
@@ -343,19 +343,19 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 				}
 			}
 			var jwks *shared.VirtualClusterAuthenticationJWKS
-			if authenticationItem.OauthBearer.Jwks != nil {
+			if r.Authentication[authenticationItem].OauthBearer.Jwks != nil {
 				var endpoint string
-				endpoint = authenticationItem.OauthBearer.Jwks.Endpoint.ValueString()
+				endpoint = r.Authentication[authenticationItem].OauthBearer.Jwks.Endpoint.ValueString()
 
 				timeout := new(string)
-				if !authenticationItem.OauthBearer.Jwks.Timeout.IsUnknown() && !authenticationItem.OauthBearer.Jwks.Timeout.IsNull() {
-					*timeout = authenticationItem.OauthBearer.Jwks.Timeout.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.IsNull() {
+					*timeout = r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.ValueString()
 				} else {
 					timeout = nil
 				}
 				cacheExpiration := new(string)
-				if !authenticationItem.OauthBearer.Jwks.CacheExpiration.IsUnknown() && !authenticationItem.OauthBearer.Jwks.CacheExpiration.IsNull() {
-					*cacheExpiration = authenticationItem.OauthBearer.Jwks.CacheExpiration.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.IsNull() {
+					*cacheExpiration = r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.ValueString()
 				} else {
 					cacheExpiration = nil
 				}
@@ -366,13 +366,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 				}
 			}
 			var validate *shared.VirtualClusterAuthenticationValidate
-			if authenticationItem.OauthBearer.Validate != nil {
+			if r.Authentication[authenticationItem].OauthBearer.Validate != nil {
 				var audiences []shared.VirtualClusterAuthenticationAudience
-				if authenticationItem.OauthBearer.Validate.Audiences != nil {
-					audiences = make([]shared.VirtualClusterAuthenticationAudience, 0, len(authenticationItem.OauthBearer.Validate.Audiences))
-					for _, audiencesItem := range authenticationItem.OauthBearer.Validate.Audiences {
+				if r.Authentication[authenticationItem].OauthBearer.Validate.Audiences != nil {
+					audiences = make([]shared.VirtualClusterAuthenticationAudience, 0, len(r.Authentication[authenticationItem].OauthBearer.Validate.Audiences))
+					for audiencesIndex := range r.Authentication[authenticationItem].OauthBearer.Validate.Audiences {
 						var name1 string
-						name1 = audiencesItem.Name.ValueString()
+						name1 = r.Authentication[authenticationItem].OauthBearer.Validate.Audiences[audiencesIndex].Name.ValueString()
 
 						audiences = append(audiences, shared.VirtualClusterAuthenticationAudience{
 							Name: name1,
@@ -380,8 +380,8 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 					}
 				}
 				issuer := new(string)
-				if !authenticationItem.OauthBearer.Validate.Issuer.IsUnknown() && !authenticationItem.OauthBearer.Validate.Issuer.IsNull() {
-					*issuer = authenticationItem.OauthBearer.Validate.Issuer.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.IsNull() {
+					*issuer = r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.ValueString()
 				} else {
 					issuer = nil
 				}
@@ -410,14 +410,14 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 		var additional *shared.VirtualClusterNamespaceAdditionalProperties
 		if r.Namespace.Additional != nil {
 			topics := make([]shared.VirtualClusterNamespaceTopicSelector, 0, len(r.Namespace.Additional.Topics))
-			for _, topicsItem := range r.Namespace.Additional.Topics {
-				if topicsItem.Glob != nil {
+			for topicsItem := range r.Namespace.Additional.Topics {
+				if r.Namespace.Additional.Topics[topicsItem].Glob != nil {
 					var glob string
-					glob = topicsItem.Glob.Glob.ValueString()
+					glob = r.Namespace.Additional.Topics[topicsItem].Glob.Glob.ValueString()
 
 					conflict := new(shared.Conflict)
-					if !topicsItem.Glob.Conflict.IsUnknown() && !topicsItem.Glob.Conflict.IsNull() {
-						*conflict = shared.Conflict(topicsItem.Glob.Conflict.ValueString())
+					if !r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.IsUnknown() && !r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.IsNull() {
+						*conflict = shared.Conflict(r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.ValueString())
 					} else {
 						conflict = nil
 					}
@@ -429,13 +429,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 						VirtualClusterNamespaceTopicSelectorGlob: &virtualClusterNamespaceTopicSelectorGlob,
 					})
 				}
-				if topicsItem.ExactList != nil {
+				if r.Namespace.Additional.Topics[topicsItem].ExactList != nil {
 					var exactList []shared.NamespaceExactAllowListItem
-					if topicsItem.ExactList.ExactList != nil {
-						exactList = make([]shared.NamespaceExactAllowListItem, 0, len(topicsItem.ExactList.ExactList))
-						for _, exactListItem := range topicsItem.ExactList.ExactList {
+					if r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList != nil {
+						exactList = make([]shared.NamespaceExactAllowListItem, 0, len(r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList))
+						for exactListIndex := range r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList {
 							var backend string
-							backend = exactListItem.Backend.ValueString()
+							backend = r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList[exactListIndex].Backend.ValueString()
 
 							exactList = append(exactList, shared.NamespaceExactAllowListItem{
 								Backend: backend,
@@ -443,8 +443,8 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 						}
 					}
 					conflict1 := new(shared.VirtualClusterNamespaceTopicSelectorExactListConflict)
-					if !topicsItem.ExactList.Conflict.IsUnknown() && !topicsItem.ExactList.Conflict.IsNull() {
-						*conflict1 = shared.VirtualClusterNamespaceTopicSelectorExactListConflict(topicsItem.ExactList.Conflict.ValueString())
+					if !r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.IsUnknown() && !r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.IsNull() {
+						*conflict1 = shared.VirtualClusterNamespaceTopicSelectorExactListConflict(r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.ValueString())
 					} else {
 						conflict1 = nil
 					}
@@ -458,10 +458,10 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 				}
 			}
 			consumerGroups := make([]shared.VirtualClusterNamespaceIDSelector, 0, len(r.Namespace.Additional.ConsumerGroups))
-			for _, consumerGroupsItem := range r.Namespace.Additional.ConsumerGroups {
-				if consumerGroupsItem.Glob != nil {
+			for consumerGroupsItem := range r.Namespace.Additional.ConsumerGroups {
+				if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].Glob != nil {
 					var glob1 string
-					glob1 = consumerGroupsItem.Glob.Glob.ValueString()
+					glob1 = r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].Glob.Glob.ValueString()
 
 					virtualClusterNamespaceIDSelectorGlob := shared.VirtualClusterNamespaceIDSelectorGlob{
 						Glob: glob1,
@@ -470,13 +470,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 						VirtualClusterNamespaceIDSelectorGlob: &virtualClusterNamespaceIDSelectorGlob,
 					})
 				}
-				if consumerGroupsItem.ExactList != nil {
+				if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList != nil {
 					var exactList1 []shared.ExactList
-					if consumerGroupsItem.ExactList.ExactList != nil {
-						exactList1 = make([]shared.ExactList, 0, len(consumerGroupsItem.ExactList.ExactList))
-						for _, exactListItem1 := range consumerGroupsItem.ExactList.ExactList {
+					if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList != nil {
+						exactList1 = make([]shared.ExactList, 0, len(r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList))
+						for exactListIndex1 := range r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList {
 							var value string
-							value = exactListItem1.Value.ValueString()
+							value = r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList[exactListIndex1].Value.ValueString()
 
 							exactList1 = append(exactList1, shared.ExactList{
 								Value: value,
@@ -507,10 +507,10 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedCreateVirtualClusterRe
 	dnsLabel = r.DNSLabel.ValueString()
 
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -552,15 +552,44 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 		ID: id,
 	}
 	authentication := make([]shared.VirtualClusterAuthenticationSensitiveDataAwareScheme, 0, len(r.Authentication))
-	for _, authenticationItem := range r.Authentication {
-		if authenticationItem.Anonymous != nil {
+	for authenticationItem := range r.Authentication {
+		if r.Authentication[authenticationItem].Anonymous != nil {
 			virtualClusterAuthenticationAnonymous := shared.VirtualClusterAuthenticationAnonymous{}
 			authentication = append(authentication, shared.VirtualClusterAuthenticationSensitiveDataAwareScheme{
 				VirtualClusterAuthenticationAnonymous: &virtualClusterAuthenticationAnonymous,
 			})
 		}
-		if authenticationItem.SaslScram != nil {
-			algorithm := shared.VirtualClusterAuthenticationSaslScramAlgorithm(authenticationItem.SaslScram.Algorithm.ValueString())
+		if r.Authentication[authenticationItem].SaslPlain != nil {
+			mediation := shared.VirtualClusterAuthenticationSaslPlainSensitiveDataAwareMediation(r.Authentication[authenticationItem].SaslPlain.Mediation.ValueString())
+			var principals []shared.VirtualClusterAuthenticationPrincipalSensitiveDataAware
+			if r.Authentication[authenticationItem].SaslPlain.Principals != nil {
+				principals = make([]shared.VirtualClusterAuthenticationPrincipalSensitiveDataAware, 0, len(r.Authentication[authenticationItem].SaslPlain.Principals))
+				for principalsIndex := range r.Authentication[authenticationItem].SaslPlain.Principals {
+					var username string
+					username = r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Username.ValueString()
+
+					password := new(string)
+					if !r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Password.IsUnknown() && !r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Password.IsNull() {
+						*password = r.Authentication[authenticationItem].SaslPlain.Principals[principalsIndex].Password.ValueString()
+					} else {
+						password = nil
+					}
+					principals = append(principals, shared.VirtualClusterAuthenticationPrincipalSensitiveDataAware{
+						Username: username,
+						Password: password,
+					})
+				}
+			}
+			virtualClusterAuthenticationSaslPlainSensitiveDataAware := shared.VirtualClusterAuthenticationSaslPlainSensitiveDataAware{
+				Mediation:  mediation,
+				Principals: principals,
+			}
+			authentication = append(authentication, shared.VirtualClusterAuthenticationSensitiveDataAwareScheme{
+				VirtualClusterAuthenticationSaslPlainSensitiveDataAware: &virtualClusterAuthenticationSaslPlainSensitiveDataAware,
+			})
+		}
+		if r.Authentication[authenticationItem].SaslScram != nil {
+			algorithm := shared.VirtualClusterAuthenticationSaslScramAlgorithm(r.Authentication[authenticationItem].SaslScram.Algorithm.ValueString())
 			virtualClusterAuthenticationSaslScram := shared.VirtualClusterAuthenticationSaslScram{
 				Algorithm: algorithm,
 			}
@@ -568,19 +597,19 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 				VirtualClusterAuthenticationSaslScram: &virtualClusterAuthenticationSaslScram,
 			})
 		}
-		if authenticationItem.OauthBearer != nil {
-			mediation := shared.VirtualClusterAuthenticationOauthBearerMediation(authenticationItem.OauthBearer.Mediation.ValueString())
+		if r.Authentication[authenticationItem].OauthBearer != nil {
+			mediation1 := shared.VirtualClusterAuthenticationOauthBearerMediation(r.Authentication[authenticationItem].OauthBearer.Mediation.ValueString())
 			var claimsMapping *shared.VirtualClusterAuthenticationClaimsMapping
-			if authenticationItem.OauthBearer.ClaimsMapping != nil {
+			if r.Authentication[authenticationItem].OauthBearer.ClaimsMapping != nil {
 				sub := new(string)
-				if !authenticationItem.OauthBearer.ClaimsMapping.Sub.IsUnknown() && !authenticationItem.OauthBearer.ClaimsMapping.Sub.IsNull() {
-					*sub = authenticationItem.OauthBearer.ClaimsMapping.Sub.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.IsNull() {
+					*sub = r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Sub.ValueString()
 				} else {
 					sub = nil
 				}
 				scope := new(string)
-				if !authenticationItem.OauthBearer.ClaimsMapping.Scope.IsUnknown() && !authenticationItem.OauthBearer.ClaimsMapping.Scope.IsNull() {
-					*scope = authenticationItem.OauthBearer.ClaimsMapping.Scope.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.IsNull() {
+					*scope = r.Authentication[authenticationItem].OauthBearer.ClaimsMapping.Scope.ValueString()
 				} else {
 					scope = nil
 				}
@@ -590,19 +619,19 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 				}
 			}
 			var jwks *shared.VirtualClusterAuthenticationJWKS
-			if authenticationItem.OauthBearer.Jwks != nil {
+			if r.Authentication[authenticationItem].OauthBearer.Jwks != nil {
 				var endpoint string
-				endpoint = authenticationItem.OauthBearer.Jwks.Endpoint.ValueString()
+				endpoint = r.Authentication[authenticationItem].OauthBearer.Jwks.Endpoint.ValueString()
 
 				timeout := new(string)
-				if !authenticationItem.OauthBearer.Jwks.Timeout.IsUnknown() && !authenticationItem.OauthBearer.Jwks.Timeout.IsNull() {
-					*timeout = authenticationItem.OauthBearer.Jwks.Timeout.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.IsNull() {
+					*timeout = r.Authentication[authenticationItem].OauthBearer.Jwks.Timeout.ValueString()
 				} else {
 					timeout = nil
 				}
 				cacheExpiration := new(string)
-				if !authenticationItem.OauthBearer.Jwks.CacheExpiration.IsUnknown() && !authenticationItem.OauthBearer.Jwks.CacheExpiration.IsNull() {
-					*cacheExpiration = authenticationItem.OauthBearer.Jwks.CacheExpiration.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.IsNull() {
+					*cacheExpiration = r.Authentication[authenticationItem].OauthBearer.Jwks.CacheExpiration.ValueString()
 				} else {
 					cacheExpiration = nil
 				}
@@ -613,13 +642,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 				}
 			}
 			var validate *shared.VirtualClusterAuthenticationValidate
-			if authenticationItem.OauthBearer.Validate != nil {
+			if r.Authentication[authenticationItem].OauthBearer.Validate != nil {
 				var audiences []shared.VirtualClusterAuthenticationAudience
-				if authenticationItem.OauthBearer.Validate.Audiences != nil {
-					audiences = make([]shared.VirtualClusterAuthenticationAudience, 0, len(authenticationItem.OauthBearer.Validate.Audiences))
-					for _, audiencesItem := range authenticationItem.OauthBearer.Validate.Audiences {
+				if r.Authentication[authenticationItem].OauthBearer.Validate.Audiences != nil {
+					audiences = make([]shared.VirtualClusterAuthenticationAudience, 0, len(r.Authentication[authenticationItem].OauthBearer.Validate.Audiences))
+					for audiencesIndex := range r.Authentication[authenticationItem].OauthBearer.Validate.Audiences {
 						var name1 string
-						name1 = audiencesItem.Name.ValueString()
+						name1 = r.Authentication[authenticationItem].OauthBearer.Validate.Audiences[audiencesIndex].Name.ValueString()
 
 						audiences = append(audiences, shared.VirtualClusterAuthenticationAudience{
 							Name: name1,
@@ -627,8 +656,8 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 					}
 				}
 				issuer := new(string)
-				if !authenticationItem.OauthBearer.Validate.Issuer.IsUnknown() && !authenticationItem.OauthBearer.Validate.Issuer.IsNull() {
-					*issuer = authenticationItem.OauthBearer.Validate.Issuer.ValueString()
+				if !r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.IsUnknown() && !r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.IsNull() {
+					*issuer = r.Authentication[authenticationItem].OauthBearer.Validate.Issuer.ValueString()
 				} else {
 					issuer = nil
 				}
@@ -638,7 +667,7 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 				}
 			}
 			virtualClusterAuthenticationOauthBearer := shared.VirtualClusterAuthenticationOauthBearer{
-				Mediation:     mediation,
+				Mediation:     mediation1,
 				ClaimsMapping: claimsMapping,
 				Jwks:          jwks,
 				Validate:      validate,
@@ -657,14 +686,14 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 		var additional *shared.VirtualClusterNamespaceAdditionalProperties
 		if r.Namespace.Additional != nil {
 			topics := make([]shared.VirtualClusterNamespaceTopicSelector, 0, len(r.Namespace.Additional.Topics))
-			for _, topicsItem := range r.Namespace.Additional.Topics {
-				if topicsItem.Glob != nil {
+			for topicsItem := range r.Namespace.Additional.Topics {
+				if r.Namespace.Additional.Topics[topicsItem].Glob != nil {
 					var glob string
-					glob = topicsItem.Glob.Glob.ValueString()
+					glob = r.Namespace.Additional.Topics[topicsItem].Glob.Glob.ValueString()
 
 					conflict := new(shared.Conflict)
-					if !topicsItem.Glob.Conflict.IsUnknown() && !topicsItem.Glob.Conflict.IsNull() {
-						*conflict = shared.Conflict(topicsItem.Glob.Conflict.ValueString())
+					if !r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.IsUnknown() && !r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.IsNull() {
+						*conflict = shared.Conflict(r.Namespace.Additional.Topics[topicsItem].Glob.Conflict.ValueString())
 					} else {
 						conflict = nil
 					}
@@ -676,13 +705,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 						VirtualClusterNamespaceTopicSelectorGlob: &virtualClusterNamespaceTopicSelectorGlob,
 					})
 				}
-				if topicsItem.ExactList != nil {
+				if r.Namespace.Additional.Topics[topicsItem].ExactList != nil {
 					var exactList []shared.NamespaceExactAllowListItem
-					if topicsItem.ExactList.ExactList != nil {
-						exactList = make([]shared.NamespaceExactAllowListItem, 0, len(topicsItem.ExactList.ExactList))
-						for _, exactListItem := range topicsItem.ExactList.ExactList {
+					if r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList != nil {
+						exactList = make([]shared.NamespaceExactAllowListItem, 0, len(r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList))
+						for exactListIndex := range r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList {
 							var backend string
-							backend = exactListItem.Backend.ValueString()
+							backend = r.Namespace.Additional.Topics[topicsItem].ExactList.ExactList[exactListIndex].Backend.ValueString()
 
 							exactList = append(exactList, shared.NamespaceExactAllowListItem{
 								Backend: backend,
@@ -690,8 +719,8 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 						}
 					}
 					conflict1 := new(shared.VirtualClusterNamespaceTopicSelectorExactListConflict)
-					if !topicsItem.ExactList.Conflict.IsUnknown() && !topicsItem.ExactList.Conflict.IsNull() {
-						*conflict1 = shared.VirtualClusterNamespaceTopicSelectorExactListConflict(topicsItem.ExactList.Conflict.ValueString())
+					if !r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.IsUnknown() && !r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.IsNull() {
+						*conflict1 = shared.VirtualClusterNamespaceTopicSelectorExactListConflict(r.Namespace.Additional.Topics[topicsItem].ExactList.Conflict.ValueString())
 					} else {
 						conflict1 = nil
 					}
@@ -705,10 +734,10 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 				}
 			}
 			consumerGroups := make([]shared.VirtualClusterNamespaceIDSelector, 0, len(r.Namespace.Additional.ConsumerGroups))
-			for _, consumerGroupsItem := range r.Namespace.Additional.ConsumerGroups {
-				if consumerGroupsItem.Glob != nil {
+			for consumerGroupsItem := range r.Namespace.Additional.ConsumerGroups {
+				if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].Glob != nil {
 					var glob1 string
-					glob1 = consumerGroupsItem.Glob.Glob.ValueString()
+					glob1 = r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].Glob.Glob.ValueString()
 
 					virtualClusterNamespaceIDSelectorGlob := shared.VirtualClusterNamespaceIDSelectorGlob{
 						Glob: glob1,
@@ -717,13 +746,13 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 						VirtualClusterNamespaceIDSelectorGlob: &virtualClusterNamespaceIDSelectorGlob,
 					})
 				}
-				if consumerGroupsItem.ExactList != nil {
+				if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList != nil {
 					var exactList1 []shared.ExactList
-					if consumerGroupsItem.ExactList.ExactList != nil {
-						exactList1 = make([]shared.ExactList, 0, len(consumerGroupsItem.ExactList.ExactList))
-						for _, exactListItem1 := range consumerGroupsItem.ExactList.ExactList {
+					if r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList != nil {
+						exactList1 = make([]shared.ExactList, 0, len(r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList))
+						for exactListIndex1 := range r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList {
 							var value string
-							value = exactListItem1.Value.ValueString()
+							value = r.Namespace.Additional.ConsumerGroups[consumerGroupsItem].ExactList.ExactList[exactListIndex1].Value.ValueString()
 
 							exactList1 = append(exactList1, shared.ExactList{
 								Value: value,
@@ -754,10 +783,10 @@ func (r *EventGatewayVirtualClusterResourceModel) ToSharedUpdateVirtualClusterRe
 	dnsLabel = r.DNSLabel.ValueString()
 
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/mesh_resource.go
+++ b/internal/provider/mesh_resource.go
@@ -1900,7 +1900,10 @@ func (r *MeshResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/mesh_resource_sdk.go
+++ b/internal/provider/mesh_resource_sdk.go
@@ -659,11 +659,11 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 		var dataplaneProxy *shared.DataplaneProxy
 		if r.Constraints.DataplaneProxy != nil {
 			requirements := make([]shared.Requirements, 0, len(r.Constraints.DataplaneProxy.Requirements))
-			for _, requirementsItem := range r.Constraints.DataplaneProxy.Requirements {
+			for requirementsIndex := range r.Constraints.DataplaneProxy.Requirements {
 				tags := make(map[string]string)
-				for tagsKey, tagsValue := range requirementsItem.Tags {
+				for tagsKey := range r.Constraints.DataplaneProxy.Requirements[requirementsIndex].Tags {
 					var tagsInst string
-					tagsInst = tagsValue.ValueString()
+					tagsInst = r.Constraints.DataplaneProxy.Requirements[requirementsIndex].Tags[tagsKey].ValueString()
 
 					tags[tagsKey] = tagsInst
 				}
@@ -672,11 +672,11 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				})
 			}
 			restrictions := make([]shared.Restrictions, 0, len(r.Constraints.DataplaneProxy.Restrictions))
-			for _, restrictionsItem := range r.Constraints.DataplaneProxy.Restrictions {
+			for restrictionsIndex := range r.Constraints.DataplaneProxy.Restrictions {
 				tags1 := make(map[string]string)
-				for tagsKey1, tagsValue1 := range restrictionsItem.Tags {
+				for tagsKey1 := range r.Constraints.DataplaneProxy.Restrictions[restrictionsIndex].Tags {
 					var tagsInst1 string
-					tagsInst1 = tagsValue1.ValueString()
+					tagsInst1 = r.Constraints.DataplaneProxy.Restrictions[restrictionsIndex].Tags[tagsKey1].ValueString()
 
 					tags1[tagsKey1] = tagsInst1
 				}
@@ -694,23 +694,23 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 		}
 	}
 	labels := make(map[string]string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		var labelsInst string
-		labelsInst = labelsValue.ValueString()
+		labelsInst = r.Labels[labelsKey].ValueString()
 
 		labels[labelsKey] = labelsInst
 	}
 	var logging *shared.Logging
 	if r.Logging != nil {
 		backends := make([]shared.Backends, 0, len(r.Logging.Backends))
-		for _, backendsItem := range r.Logging.Backends {
+		for backendsIndex := range r.Logging.Backends {
 			var conf *shared.MeshItemLoggingConf
-			if backendsItem.Conf != nil {
+			if r.Logging.Backends[backendsIndex].Conf != nil {
 				var fileLoggingBackendConfig *shared.FileLoggingBackendConfig
-				if backendsItem.Conf.FileLoggingBackendConfig != nil {
+				if r.Logging.Backends[backendsIndex].Conf.FileLoggingBackendConfig != nil {
 					path := new(string)
-					if !backendsItem.Conf.FileLoggingBackendConfig.Path.IsUnknown() && !backendsItem.Conf.FileLoggingBackendConfig.Path.IsNull() {
-						*path = backendsItem.Conf.FileLoggingBackendConfig.Path.ValueString()
+					if !r.Logging.Backends[backendsIndex].Conf.FileLoggingBackendConfig.Path.IsUnknown() && !r.Logging.Backends[backendsIndex].Conf.FileLoggingBackendConfig.Path.IsNull() {
+						*path = r.Logging.Backends[backendsIndex].Conf.FileLoggingBackendConfig.Path.ValueString()
 					} else {
 						path = nil
 					}
@@ -724,10 +724,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var tcpLoggingBackendConfig *shared.TCPLoggingBackendConfig
-				if backendsItem.Conf.TCPLoggingBackendConfig != nil {
+				if r.Logging.Backends[backendsIndex].Conf.TCPLoggingBackendConfig != nil {
 					address := new(string)
-					if !backendsItem.Conf.TCPLoggingBackendConfig.Address.IsUnknown() && !backendsItem.Conf.TCPLoggingBackendConfig.Address.IsNull() {
-						*address = backendsItem.Conf.TCPLoggingBackendConfig.Address.ValueString()
+					if !r.Logging.Backends[backendsIndex].Conf.TCPLoggingBackendConfig.Address.IsUnknown() && !r.Logging.Backends[backendsIndex].Conf.TCPLoggingBackendConfig.Address.IsNull() {
+						*address = r.Logging.Backends[backendsIndex].Conf.TCPLoggingBackendConfig.Address.ValueString()
 					} else {
 						address = nil
 					}
@@ -742,20 +742,20 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			format := new(string)
-			if !backendsItem.Format.IsUnknown() && !backendsItem.Format.IsNull() {
-				*format = backendsItem.Format.ValueString()
+			if !r.Logging.Backends[backendsIndex].Format.IsUnknown() && !r.Logging.Backends[backendsIndex].Format.IsNull() {
+				*format = r.Logging.Backends[backendsIndex].Format.ValueString()
 			} else {
 				format = nil
 			}
 			name := new(string)
-			if !backendsItem.Name.IsUnknown() && !backendsItem.Name.IsNull() {
-				*name = backendsItem.Name.ValueString()
+			if !r.Logging.Backends[backendsIndex].Name.IsUnknown() && !r.Logging.Backends[backendsIndex].Name.IsNull() {
+				*name = r.Logging.Backends[backendsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			typeVar := new(string)
-			if !backendsItem.Type.IsUnknown() && !backendsItem.Type.IsNull() {
-				*typeVar = backendsItem.Type.ValueString()
+			if !r.Logging.Backends[backendsIndex].Type.IsUnknown() && !r.Logging.Backends[backendsIndex].Type.IsNull() {
+				*typeVar = r.Logging.Backends[backendsIndex].Type.ValueString()
 			} else {
 				typeVar = nil
 			}
@@ -811,40 +811,40 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 	var metrics *shared.Metrics
 	if r.Metrics != nil {
 		backends1 := make([]shared.MeshItemBackends, 0, len(r.Metrics.Backends))
-		for _, backendsItem1 := range r.Metrics.Backends {
+		for backendsIndex1 := range r.Metrics.Backends {
 			var conf1 *shared.MeshItemConf
-			if backendsItem1.Conf != nil {
+			if r.Metrics.Backends[backendsIndex1].Conf != nil {
 				var prometheusMetricsBackendConfig *shared.PrometheusMetricsBackendConfig
-				if backendsItem1.Conf.PrometheusMetricsBackendConfig != nil {
-					aggregate := make([]shared.Aggregate, 0, len(backendsItem1.Conf.PrometheusMetricsBackendConfig.Aggregate))
-					for _, aggregateItem := range backendsItem1.Conf.PrometheusMetricsBackendConfig.Aggregate {
+				if r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig != nil {
+					aggregate := make([]shared.Aggregate, 0, len(r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate))
+					for aggregateIndex := range r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate {
 						address1 := new(string)
-						if !aggregateItem.Address.IsUnknown() && !aggregateItem.Address.IsNull() {
-							*address1 = aggregateItem.Address.ValueString()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Address.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Address.IsNull() {
+							*address1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Address.ValueString()
 						} else {
 							address1 = nil
 						}
 						enabled := new(bool)
-						if !aggregateItem.Enabled.IsUnknown() && !aggregateItem.Enabled.IsNull() {
-							*enabled = aggregateItem.Enabled.ValueBool()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Enabled.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Enabled.IsNull() {
+							*enabled = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Enabled.ValueBool()
 						} else {
 							enabled = nil
 						}
 						name1 := new(string)
-						if !aggregateItem.Name.IsUnknown() && !aggregateItem.Name.IsNull() {
-							*name1 = aggregateItem.Name.ValueString()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Name.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Name.IsNull() {
+							*name1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Name.ValueString()
 						} else {
 							name1 = nil
 						}
 						path1 := new(string)
-						if !aggregateItem.Path.IsUnknown() && !aggregateItem.Path.IsNull() {
-							*path1 = aggregateItem.Path.ValueString()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Path.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Path.IsNull() {
+							*path1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Path.ValueString()
 						} else {
 							path1 = nil
 						}
 						port := new(int64)
-						if !aggregateItem.Port.IsUnknown() && !aggregateItem.Port.IsNull() {
-							*port = aggregateItem.Port.ValueInt64()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Port.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Port.IsNull() {
+							*port = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Aggregate[aggregateIndex].Port.ValueInt64()
 						} else {
 							port = nil
 						}
@@ -857,16 +857,16 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						})
 					}
 					var envoy *shared.Envoy
-					if backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy != nil {
+					if r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy != nil {
 						filterRegex := new(string)
-						if !backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.IsNull() {
-							*filterRegex = backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.ValueString()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.IsNull() {
+							*filterRegex = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.FilterRegex.ValueString()
 						} else {
 							filterRegex = nil
 						}
 						usedOnly := new(bool)
-						if !backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.IsNull() {
-							*usedOnly = backendsItem1.Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.ValueBool()
+						if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.IsNull() {
+							*usedOnly = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Envoy.UsedOnly.ValueBool()
 						} else {
 							usedOnly = nil
 						}
@@ -876,37 +876,37 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						}
 					}
 					path2 := new(string)
-					if !backendsItem1.Conf.PrometheusMetricsBackendConfig.Path.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.Path.IsNull() {
-						*path2 = backendsItem1.Conf.PrometheusMetricsBackendConfig.Path.ValueString()
+					if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Path.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Path.IsNull() {
+						*path2 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Path.ValueString()
 					} else {
 						path2 = nil
 					}
 					port1 := new(int64)
-					if !backendsItem1.Conf.PrometheusMetricsBackendConfig.Port.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.Port.IsNull() {
-						*port1 = backendsItem1.Conf.PrometheusMetricsBackendConfig.Port.ValueInt64()
+					if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Port.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Port.IsNull() {
+						*port1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Port.ValueInt64()
 					} else {
 						port1 = nil
 					}
 					skipMTLS := new(bool)
-					if !backendsItem1.Conf.PrometheusMetricsBackendConfig.SkipMTLS.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.SkipMTLS.IsNull() {
-						*skipMTLS = backendsItem1.Conf.PrometheusMetricsBackendConfig.SkipMTLS.ValueBool()
+					if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.SkipMTLS.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.SkipMTLS.IsNull() {
+						*skipMTLS = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.SkipMTLS.ValueBool()
 					} else {
 						skipMTLS = nil
 					}
 					tags2 := make(map[string]string)
-					for tagsKey2, tagsValue2 := range backendsItem1.Conf.PrometheusMetricsBackendConfig.Tags {
+					for tagsKey2 := range r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Tags {
 						var tagsInst2 string
-						tagsInst2 = tagsValue2.ValueString()
+						tagsInst2 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.Tags[tagsKey2].ValueString()
 
 						tags2[tagsKey2] = tagsInst2
 					}
 					var tls *shared.ConfTLS
-					if backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS != nil {
+					if r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS != nil {
 						var mode1 *shared.ConfMode
-						if backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode != nil {
+						if r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode != nil {
 							str1 := new(string)
-							if !backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.IsNull() {
-								*str1 = backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.ValueString()
+							if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.IsNull() {
+								*str1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Str.ValueString()
 							} else {
 								str1 = nil
 							}
@@ -916,8 +916,8 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 								}
 							}
 							integer1 := new(int64)
-							if !backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.IsUnknown() && !backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.IsNull() {
-								*integer1 = backendsItem1.Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.ValueInt64()
+							if !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.IsNull() {
+								*integer1 = r.Metrics.Backends[backendsIndex1].Conf.PrometheusMetricsBackendConfig.TLS.Mode.Integer.ValueInt64()
 							} else {
 								integer1 = nil
 							}
@@ -948,14 +948,14 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			name2 := new(string)
-			if !backendsItem1.Name.IsUnknown() && !backendsItem1.Name.IsNull() {
-				*name2 = backendsItem1.Name.ValueString()
+			if !r.Metrics.Backends[backendsIndex1].Name.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Name.IsNull() {
+				*name2 = r.Metrics.Backends[backendsIndex1].Name.ValueString()
 			} else {
 				name2 = nil
 			}
 			type1 := new(string)
-			if !backendsItem1.Type.IsUnknown() && !backendsItem1.Type.IsNull() {
-				*type1 = backendsItem1.Type.ValueString()
+			if !r.Metrics.Backends[backendsIndex1].Type.IsUnknown() && !r.Metrics.Backends[backendsIndex1].Type.IsNull() {
+				*type1 = r.Metrics.Backends[backendsIndex1].Type.ValueString()
 			} else {
 				type1 = nil
 			}
@@ -979,18 +979,18 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 	var mtls *shared.Mtls
 	if r.Mtls != nil {
 		backends2 := make([]shared.MeshItemMtlsBackends, 0, len(r.Mtls.Backends))
-		for _, backendsItem2 := range r.Mtls.Backends {
+		for backendsIndex2 := range r.Mtls.Backends {
 			var conf2 *shared.MeshItemMtlsConf
-			if backendsItem2.Conf != nil {
+			if r.Mtls.Backends[backendsIndex2].Conf != nil {
 				var providedCertificateAuthorityConfig *shared.ProvidedCertificateAuthorityConfig
-				if backendsItem2.Conf.ProvidedCertificateAuthorityConfig != nil {
+				if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig != nil {
 					var cert *shared.Cert
-					if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert != nil {
 						var certDataSourceFile *shared.CertDataSourceFile
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile != nil {
 							file := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.IsNull() {
-								*file = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.IsNull() {
+								*file = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceFile.File.ValueString()
 							} else {
 								file = nil
 							}
@@ -1004,10 +1004,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certDataSourceInline *shared.CertDataSourceInline
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline != nil {
 							inline := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.IsNull() {
-								*inline = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.IsNull() {
+								*inline = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInline.Inline.ValueString()
 							} else {
 								inline = nil
 							}
@@ -1021,10 +1021,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certDataSourceInlineString *shared.CertDataSourceInlineString
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString != nil {
 							inlineString := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.IsNull() {
-								*inlineString = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.IsNull() {
+								*inlineString = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceInlineString.InlineString.ValueString()
 							} else {
 								inlineString = nil
 							}
@@ -1038,10 +1038,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certDataSourceSecret *shared.CertDataSourceSecret
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret != nil {
 							secret := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.IsNull() {
-								*secret = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.IsNull() {
+								*secret = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Cert.DataSourceSecret.Secret.ValueString()
 							} else {
 								secret = nil
 							}
@@ -1056,12 +1056,12 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						}
 					}
 					var key *shared.Key
-					if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key != nil {
 						var keyDataSourceFile *shared.KeyDataSourceFile
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile != nil {
 							file1 := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.IsNull() {
-								*file1 = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.IsNull() {
+								*file1 = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceFile.File.ValueString()
 							} else {
 								file1 = nil
 							}
@@ -1075,10 +1075,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var keyDataSourceInline *shared.KeyDataSourceInline
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline != nil {
 							inline1 := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.IsNull() {
-								*inline1 = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.IsNull() {
+								*inline1 = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInline.Inline.ValueString()
 							} else {
 								inline1 = nil
 							}
@@ -1092,10 +1092,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var keyDataSourceInlineString *shared.KeyDataSourceInlineString
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString != nil {
 							inlineString1 := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.IsNull() {
-								*inlineString1 = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.IsNull() {
+								*inlineString1 = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceInlineString.InlineString.ValueString()
 							} else {
 								inlineString1 = nil
 							}
@@ -1109,10 +1109,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var keyDataSourceSecret *shared.KeyDataSourceSecret
-						if backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret != nil {
 							secret1 := new(string)
-							if !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.IsNull() {
-								*secret1 = backendsItem2.Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.IsNull() {
+								*secret1 = r.Mtls.Backends[backendsIndex2].Conf.ProvidedCertificateAuthorityConfig.Key.DataSourceSecret.Secret.ValueString()
 							} else {
 								secret1 = nil
 							}
@@ -1137,18 +1137,18 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var builtinCertificateAuthorityConfig *shared.BuiltinCertificateAuthorityConfig
-				if backendsItem2.Conf.BuiltinCertificateAuthorityConfig != nil {
+				if r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig != nil {
 					var caCert *shared.BuiltinCertificateAuthorityConfigConfCaCert
-					if backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert != nil {
 						expiration := new(string)
-						if !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsUnknown() && !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsNull() {
-							*expiration = backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.ValueString()
+						if !r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.IsNull() {
+							*expiration = r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.Expiration.ValueString()
 						} else {
 							expiration = nil
 						}
 						rsaBits := new(int64)
-						if !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsUnknown() && !backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsNull() {
-							*rsaBits = backendsItem2.Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.ValueInt64()
+						if !r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.IsNull() {
+							*rsaBits = r.Mtls.Backends[backendsIndex2].Conf.BuiltinCertificateAuthorityConfig.CaCert.RsaBits.ValueInt64()
 						} else {
 							rsaBits = nil
 						}
@@ -1167,46 +1167,46 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var vaultCertificateAuthorityConfig *shared.VaultCertificateAuthorityConfig
-				if backendsItem2.Conf.VaultCertificateAuthorityConfig != nil {
+				if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig != nil {
 					var vaultCertificateAuthorityConfigFromCp *shared.VaultCertificateAuthorityConfigFromCp
-					if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp != nil {
 						var fromCp *shared.FromCp
-						if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp != nil {
 							address2 := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.IsNull() {
-								*address2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.IsNull() {
+								*address2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Address.ValueString()
 							} else {
 								address2 = nil
 							}
 							agentAddress := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.IsNull() {
-								*agentAddress = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.IsNull() {
+								*agentAddress = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.AgentAddress.ValueString()
 							} else {
 								agentAddress = nil
 							}
 							var auth *shared.VaultCertificateAuthorityConfigAuth
-							if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth != nil {
+							if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth != nil {
 								var vaultCertificateAuthorityConfigFromCpAuthAws *shared.VaultCertificateAuthorityConfigFromCpAuthAws
-								if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws != nil {
 									var aws *shared.Aws
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws != nil {
 										iamServerIDHeader := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.IsNull() {
-											*iamServerIDHeader = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.IsNull() {
+											*iamServerIDHeader = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.IamServerIDHeader.ValueString()
 										} else {
 											iamServerIDHeader = nil
 										}
 										role := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.IsNull() {
-											*role = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.IsNull() {
+											*role = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Role.ValueString()
 										} else {
 											role = nil
 										}
 										var typeVar1 *shared.AuthType
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type != nil {
 											str2 := new(string)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.IsNull() {
-												*str2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.ValueString()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.IsNull() {
+												*str2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Str.ValueString()
 											} else {
 												str2 = nil
 											}
@@ -1216,8 +1216,8 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											integer2 := new(int64)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.IsNull() {
-												*integer2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.ValueInt64()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.IsNull() {
+												*integer2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthAws.Aws.Type.Integer.ValueInt64()
 											} else {
 												integer2 = nil
 											}
@@ -1243,16 +1243,16 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var vaultCertificateAuthorityConfigFromCpAuthTLS *shared.VaultCertificateAuthorityConfigFromCpAuthTLS
-								if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS != nil {
 									var tls1 *shared.AuthTLS
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS != nil {
 										var clientCert *shared.AuthClientCert
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert != nil {
 											var clientCertDataSourceFile *shared.ClientCertDataSourceFile
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile != nil {
 												file2 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.IsNull() {
-													*file2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.IsNull() {
+													*file2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceFile.File.ValueString()
 												} else {
 													file2 = nil
 												}
@@ -1266,10 +1266,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientCertDataSourceInline *shared.ClientCertDataSourceInline
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline != nil {
 												inline2 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.IsNull() {
-													*inline2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.IsNull() {
+													*inline2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInline.Inline.ValueString()
 												} else {
 													inline2 = nil
 												}
@@ -1283,10 +1283,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientCertDataSourceInlineString *shared.ClientCertDataSourceInlineString
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString != nil {
 												inlineString2 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.IsNull() {
-													*inlineString2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.IsNull() {
+													*inlineString2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceInlineString.InlineString.ValueString()
 												} else {
 													inlineString2 = nil
 												}
@@ -1300,10 +1300,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientCertDataSourceSecret *shared.ClientCertDataSourceSecret
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret != nil {
 												secret2 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.IsNull() {
-													*secret2 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.IsNull() {
+													*secret2 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientCert.DataSourceSecret.Secret.ValueString()
 												} else {
 													secret2 = nil
 												}
@@ -1318,12 +1318,12 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 											}
 										}
 										var clientKey *shared.AuthClientKey
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey != nil {
 											var clientKeyDataSourceFile *shared.ClientKeyDataSourceFile
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile != nil {
 												file3 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.IsNull() {
-													*file3 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.IsNull() {
+													*file3 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceFile.File.ValueString()
 												} else {
 													file3 = nil
 												}
@@ -1337,10 +1337,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientKeyDataSourceInline *shared.ClientKeyDataSourceInline
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline != nil {
 												inline3 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.IsNull() {
-													*inline3 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.IsNull() {
+													*inline3 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInline.Inline.ValueString()
 												} else {
 													inline3 = nil
 												}
@@ -1354,10 +1354,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientKeyDataSourceInlineString *shared.ClientKeyDataSourceInlineString
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString != nil {
 												inlineString3 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.IsNull() {
-													*inlineString3 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.IsNull() {
+													*inlineString3 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceInlineString.InlineString.ValueString()
 												} else {
 													inlineString3 = nil
 												}
@@ -1371,10 +1371,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 												}
 											}
 											var clientKeyDataSourceSecret *shared.ClientKeyDataSourceSecret
-											if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret != nil {
+											if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret != nil {
 												secret3 := new(string)
-												if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.IsNull() {
-													*secret3 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.ValueString()
+												if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.IsNull() {
+													*secret3 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthTLS.TLS.ClientKey.DataSourceSecret.Secret.ValueString()
 												} else {
 													secret3 = nil
 												}
@@ -1403,14 +1403,14 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var vaultCertificateAuthorityConfigFromCpAuthToken *shared.VaultCertificateAuthorityConfigFromCpAuthToken
-								if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken != nil {
 									var token *shared.Token
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token != nil {
 										var tokenDataSourceFile *shared.TokenDataSourceFile
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile != nil {
 											file4 := new(string)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.IsNull() {
-												*file4 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.ValueString()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.IsNull() {
+												*file4 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceFile.File.ValueString()
 											} else {
 												file4 = nil
 											}
@@ -1424,10 +1424,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 											}
 										}
 										var tokenDataSourceInline *shared.TokenDataSourceInline
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline != nil {
 											inline4 := new(string)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.IsNull() {
-												*inline4 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.ValueString()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.IsNull() {
+												*inline4 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInline.Inline.ValueString()
 											} else {
 												inline4 = nil
 											}
@@ -1441,10 +1441,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 											}
 										}
 										var tokenDataSourceInlineString *shared.TokenDataSourceInlineString
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString != nil {
 											inlineString4 := new(string)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.IsNull() {
-												*inlineString4 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.ValueString()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.IsNull() {
+												*inlineString4 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceInlineString.InlineString.ValueString()
 											} else {
 												inlineString4 = nil
 											}
@@ -1458,10 +1458,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 											}
 										}
 										var tokenDataSourceSecret *shared.TokenDataSourceSecret
-										if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret != nil {
+										if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret != nil {
 											secret4 := new(string)
-											if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.IsNull() {
-												*secret4 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.ValueString()
+											if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.IsNull() {
+												*secret4 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Auth.VaultCertificateAuthorityConfigFromCpAuthToken.Token.DataSourceSecret.Secret.ValueString()
 											} else {
 												secret4 = nil
 											}
@@ -1486,38 +1486,38 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 								}
 							}
 							commonName := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.IsNull() {
-								*commonName = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.IsNull() {
+								*commonName = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.CommonName.ValueString()
 							} else {
 								commonName = nil
 							}
 							namespace := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.IsNull() {
-								*namespace = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.IsNull() {
+								*namespace = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Namespace.ValueString()
 							} else {
 								namespace = nil
 							}
 							pki := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.IsNull() {
-								*pki = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.IsNull() {
+								*pki = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Pki.ValueString()
 							} else {
 								pki = nil
 							}
 							role1 := new(string)
-							if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.IsNull() {
-								*role1 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.IsNull() {
+								*role1 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.Role.ValueString()
 							} else {
 								role1 = nil
 							}
 							var tls2 *shared.VaultCertificateAuthorityConfigTLS
-							if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS != nil {
+							if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS != nil {
 								var caCert1 *shared.VaultCertificateAuthorityConfigCaCert
-								if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert != nil {
 									var vaultCertificateAuthorityConfigFromCpCaCertDataSourceFile *shared.VaultCertificateAuthorityConfigFromCpCaCertDataSourceFile
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile != nil {
 										file5 := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.IsNull() {
-											*file5 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.IsNull() {
+											*file5 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceFile.File.ValueString()
 										} else {
 											file5 = nil
 										}
@@ -1531,10 +1531,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 										}
 									}
 									var vaultCertificateAuthorityConfigFromCpCaCertDataSourceInline *shared.VaultCertificateAuthorityConfigFromCpCaCertDataSourceInline
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline != nil {
 										inline5 := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.IsNull() {
-											*inline5 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.IsNull() {
+											*inline5 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInline.Inline.ValueString()
 										} else {
 											inline5 = nil
 										}
@@ -1548,10 +1548,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 										}
 									}
 									var vaultCertificateAuthorityConfigFromCpCaCertDataSourceInlineString *shared.VaultCertificateAuthorityConfigFromCpCaCertDataSourceInlineString
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString != nil {
 										inlineString5 := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.IsNull() {
-											*inlineString5 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.IsNull() {
+											*inlineString5 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceInlineString.InlineString.ValueString()
 										} else {
 											inlineString5 = nil
 										}
@@ -1565,10 +1565,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 										}
 									}
 									var vaultCertificateAuthorityConfigFromCpCaCertDataSourceSecret *shared.VaultCertificateAuthorityConfigFromCpCaCertDataSourceSecret
-									if backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret != nil {
+									if r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret != nil {
 										secret5 := new(string)
-										if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.IsNull() {
-											*secret5 = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.ValueString()
+										if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.IsNull() {
+											*secret5 = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.CaCert.DataSourceSecret.Secret.ValueString()
 										} else {
 											secret5 = nil
 										}
@@ -1583,14 +1583,14 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								serverName := new(string)
-								if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.IsNull() {
-									*serverName = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.ValueString()
+								if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.IsNull() {
+									*serverName = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.ServerName.ValueString()
 								} else {
 									serverName = nil
 								}
 								skipVerify := new(bool)
-								if !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.IsUnknown() && !backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.IsNull() {
-									*skipVerify = backendsItem2.Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.ValueBool()
+								if !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.IsNull() {
+									*skipVerify = r.Mtls.Backends[backendsIndex2].Conf.VaultCertificateAuthorityConfig.VaultCertificateAuthorityConfigFromCp.FromCp.TLS.SkipVerify.ValueBool()
 								} else {
 									skipVerify = nil
 								}
@@ -1627,24 +1627,24 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var acmCertificateAuthorityConfig *shared.ACMCertificateAuthorityConfig
-				if backendsItem2.Conf.ACMCertificateAuthorityConfig != nil {
+				if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig != nil {
 					arn := new(string)
-					if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Arn.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Arn.IsNull() {
-						*arn = backendsItem2.Conf.ACMCertificateAuthorityConfig.Arn.ValueString()
+					if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Arn.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Arn.IsNull() {
+						*arn = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Arn.ValueString()
 					} else {
 						arn = nil
 					}
 					var auth1 *shared.Auth
-					if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth != nil {
 						var awsCredentials *shared.AwsCredentials
-						if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials != nil {
 							var accessKey *shared.AccessKey
-							if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey != nil {
+							if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey != nil {
 								var accessKeyDataSourceFile *shared.AccessKeyDataSourceFile
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile != nil {
 									file6 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.IsNull() {
-										*file6 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.IsNull() {
+										*file6 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceFile.File.ValueString()
 									} else {
 										file6 = nil
 									}
@@ -1658,10 +1658,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeyDataSourceInline *shared.AccessKeyDataSourceInline
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline != nil {
 									inline6 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.IsNull() {
-										*inline6 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.IsNull() {
+										*inline6 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInline.Inline.ValueString()
 									} else {
 										inline6 = nil
 									}
@@ -1675,10 +1675,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeyDataSourceInlineString *shared.AccessKeyDataSourceInlineString
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString != nil {
 									inlineString6 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.IsNull() {
-										*inlineString6 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.IsNull() {
+										*inlineString6 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceInlineString.InlineString.ValueString()
 									} else {
 										inlineString6 = nil
 									}
@@ -1692,10 +1692,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeyDataSourceSecret *shared.AccessKeyDataSourceSecret
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret != nil {
 									secret6 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.IsNull() {
-										*secret6 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.IsNull() {
+										*secret6 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKey.DataSourceSecret.Secret.ValueString()
 									} else {
 										secret6 = nil
 									}
@@ -1710,12 +1710,12 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 								}
 							}
 							var accessKeySecret *shared.AccessKeySecret
-							if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret != nil {
+							if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret != nil {
 								var accessKeySecretDataSourceFile *shared.AccessKeySecretDataSourceFile
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile != nil {
 									file7 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.IsNull() {
-										*file7 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.IsNull() {
+										*file7 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceFile.File.ValueString()
 									} else {
 										file7 = nil
 									}
@@ -1729,10 +1729,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeySecretDataSourceInline *shared.AccessKeySecretDataSourceInline
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline != nil {
 									inline7 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.IsNull() {
-										*inline7 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.IsNull() {
+										*inline7 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInline.Inline.ValueString()
 									} else {
 										inline7 = nil
 									}
@@ -1746,10 +1746,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeySecretDataSourceInlineString *shared.AccessKeySecretDataSourceInlineString
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString != nil {
 									inlineString7 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.IsNull() {
-										*inlineString7 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.IsNull() {
+										*inlineString7 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceInlineString.InlineString.ValueString()
 									} else {
 										inlineString7 = nil
 									}
@@ -1763,10 +1763,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 									}
 								}
 								var accessKeySecretDataSourceSecret *shared.AccessKeySecretDataSourceSecret
-								if backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret != nil {
+								if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret != nil {
 									secret7 := new(string)
-									if !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.IsNull() {
-										*secret7 = backendsItem2.Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.ValueString()
+									if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.IsNull() {
+										*secret7 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.Auth.AwsCredentials.AccessKeySecret.DataSourceSecret.Secret.ValueString()
 									} else {
 										secret7 = nil
 									}
@@ -1790,12 +1790,12 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						}
 					}
 					var caCert2 *shared.ConfCaCert
-					if backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert != nil {
 						var caCertDataSourceFile *shared.CaCertDataSourceFile
-						if backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile != nil {
 							file8 := new(string)
-							if !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsNull() {
-								*file8 = backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsNull() {
+								*file8 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceFile.File.ValueString()
 							} else {
 								file8 = nil
 							}
@@ -1809,10 +1809,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var caCertDataSourceInline *shared.CaCertDataSourceInline
-						if backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline != nil {
 							inline8 := new(string)
-							if !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsNull() {
-								*inline8 = backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsNull() {
+								*inline8 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.ValueString()
 							} else {
 								inline8 = nil
 							}
@@ -1826,10 +1826,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var caCertDataSourceInlineString *shared.CaCertDataSourceInlineString
-						if backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString != nil {
 							inlineString8 := new(string)
-							if !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsNull() {
-								*inlineString8 = backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsNull() {
+								*inlineString8 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.ValueString()
 							} else {
 								inlineString8 = nil
 							}
@@ -1843,10 +1843,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var caCertDataSourceSecret *shared.CaCertDataSourceSecret
-						if backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret != nil {
 							secret8 := new(string)
-							if !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsNull() {
-								*secret8 = backendsItem2.Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsNull() {
+								*secret8 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.ValueString()
 							} else {
 								secret8 = nil
 							}
@@ -1861,8 +1861,8 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						}
 					}
 					commonName1 := new(string)
-					if !backendsItem2.Conf.ACMCertificateAuthorityConfig.CommonName.IsUnknown() && !backendsItem2.Conf.ACMCertificateAuthorityConfig.CommonName.IsNull() {
-						*commonName1 = backendsItem2.Conf.ACMCertificateAuthorityConfig.CommonName.ValueString()
+					if !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CommonName.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CommonName.IsNull() {
+						*commonName1 = r.Mtls.Backends[backendsIndex2].Conf.ACMCertificateAuthorityConfig.CommonName.ValueString()
 					} else {
 						commonName1 = nil
 					}
@@ -1879,14 +1879,14 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var certManagerCertificateAuthorityConfig *shared.CertManagerCertificateAuthorityConfig
-				if backendsItem2.Conf.CertManagerCertificateAuthorityConfig != nil {
+				if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig != nil {
 					var caCert3 *shared.CertManagerCertificateAuthorityConfigConfCaCert
-					if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert != nil {
 						var certManagerCertificateAuthorityConfigCaCertDataSourceFile *shared.CertManagerCertificateAuthorityConfigCaCertDataSourceFile
-						if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile != nil {
 							file9 := new(string)
-							if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsNull() {
-								*file9 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.IsNull() {
+								*file9 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceFile.File.ValueString()
 							} else {
 								file9 = nil
 							}
@@ -1900,10 +1900,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certManagerCertificateAuthorityConfigCaCertDataSourceInline *shared.CertManagerCertificateAuthorityConfigCaCertDataSourceInline
-						if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline != nil {
 							inline9 := new(string)
-							if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsNull() {
-								*inline9 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.IsNull() {
+								*inline9 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInline.Inline.ValueString()
 							} else {
 								inline9 = nil
 							}
@@ -1917,10 +1917,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certManagerCertificateAuthorityConfigCaCertDataSourceInlineString *shared.CertManagerCertificateAuthorityConfigCaCertDataSourceInlineString
-						if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString != nil {
 							inlineString9 := new(string)
-							if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsNull() {
-								*inlineString9 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.IsNull() {
+								*inlineString9 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceInlineString.InlineString.ValueString()
 							} else {
 								inlineString9 = nil
 							}
@@ -1934,10 +1934,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 							}
 						}
 						var certManagerCertificateAuthorityConfigCaCertDataSourceSecret *shared.CertManagerCertificateAuthorityConfigCaCertDataSourceSecret
-						if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret != nil {
+						if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret != nil {
 							secret9 := new(string)
-							if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsNull() {
-								*secret9 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.ValueString()
+							if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.IsNull() {
+								*secret9 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CaCert.DataSourceSecret.Secret.ValueString()
 							} else {
 								secret9 = nil
 							}
@@ -1952,32 +1952,32 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 						}
 					}
 					commonName2 := new(string)
-					if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CommonName.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CommonName.IsNull() {
-						*commonName2 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.CommonName.ValueString()
+					if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CommonName.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CommonName.IsNull() {
+						*commonName2 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.CommonName.ValueString()
 					} else {
 						commonName2 = nil
 					}
-					dnsNames := make([]string, 0, len(backendsItem2.Conf.CertManagerCertificateAuthorityConfig.DNSNames))
-					for _, dnsNamesItem := range backendsItem2.Conf.CertManagerCertificateAuthorityConfig.DNSNames {
-						dnsNames = append(dnsNames, dnsNamesItem.ValueString())
+					dnsNames := make([]string, 0, len(r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.DNSNames))
+					for dnsNamesIndex := range r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.DNSNames {
+						dnsNames = append(dnsNames, r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.DNSNames[dnsNamesIndex].ValueString())
 					}
 					var issuerRef *shared.IssuerRef
-					if backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef != nil {
+					if r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef != nil {
 						group := new(string)
-						if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.IsNull() {
-							*group = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.ValueString()
+						if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.IsNull() {
+							*group = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Group.ValueString()
 						} else {
 							group = nil
 						}
 						kind := new(string)
-						if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.IsNull() {
-							*kind = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.ValueString()
+						if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.IsNull() {
+							*kind = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Kind.ValueString()
 						} else {
 							kind = nil
 						}
 						name3 := new(string)
-						if !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.IsUnknown() && !backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.IsNull() {
-							*name3 = backendsItem2.Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.ValueString()
+						if !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.IsNull() {
+							*name3 = r.Mtls.Backends[backendsIndex2].Conf.CertManagerCertificateAuthorityConfig.IssuerRef.Name.ValueString()
 						} else {
 							name3 = nil
 						}
@@ -2001,18 +2001,18 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			var dpCert *shared.DpCert
-			if backendsItem2.DpCert != nil {
+			if r.Mtls.Backends[backendsIndex2].DpCert != nil {
 				var requestTimeout *shared.RequestTimeout
-				if backendsItem2.DpCert.RequestTimeout != nil {
+				if r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout != nil {
 					nanos := new(int64)
-					if !backendsItem2.DpCert.RequestTimeout.Nanos.IsUnknown() && !backendsItem2.DpCert.RequestTimeout.Nanos.IsNull() {
-						*nanos = backendsItem2.DpCert.RequestTimeout.Nanos.ValueInt64()
+					if !r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Nanos.IsUnknown() && !r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Nanos.IsNull() {
+						*nanos = r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Nanos.ValueInt64()
 					} else {
 						nanos = nil
 					}
 					seconds := new(int64)
-					if !backendsItem2.DpCert.RequestTimeout.Seconds.IsUnknown() && !backendsItem2.DpCert.RequestTimeout.Seconds.IsNull() {
-						*seconds = backendsItem2.DpCert.RequestTimeout.Seconds.ValueInt64()
+					if !r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Seconds.IsUnknown() && !r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Seconds.IsNull() {
+						*seconds = r.Mtls.Backends[backendsIndex2].DpCert.RequestTimeout.Seconds.ValueInt64()
 					} else {
 						seconds = nil
 					}
@@ -2022,10 +2022,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var rotation *shared.Rotation
-				if backendsItem2.DpCert.Rotation != nil {
+				if r.Mtls.Backends[backendsIndex2].DpCert.Rotation != nil {
 					expiration1 := new(string)
-					if !backendsItem2.DpCert.Rotation.Expiration.IsUnknown() && !backendsItem2.DpCert.Rotation.Expiration.IsNull() {
-						*expiration1 = backendsItem2.DpCert.Rotation.Expiration.ValueString()
+					if !r.Mtls.Backends[backendsIndex2].DpCert.Rotation.Expiration.IsUnknown() && !r.Mtls.Backends[backendsIndex2].DpCert.Rotation.Expiration.IsNull() {
+						*expiration1 = r.Mtls.Backends[backendsIndex2].DpCert.Rotation.Expiration.ValueString()
 					} else {
 						expiration1 = nil
 					}
@@ -2039,10 +2039,10 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			var mode2 *shared.MeshItemMtlsMode
-			if backendsItem2.Mode != nil {
+			if r.Mtls.Backends[backendsIndex2].Mode != nil {
 				str3 := new(string)
-				if !backendsItem2.Mode.Str.IsUnknown() && !backendsItem2.Mode.Str.IsNull() {
-					*str3 = backendsItem2.Mode.Str.ValueString()
+				if !r.Mtls.Backends[backendsIndex2].Mode.Str.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Mode.Str.IsNull() {
+					*str3 = r.Mtls.Backends[backendsIndex2].Mode.Str.ValueString()
 				} else {
 					str3 = nil
 				}
@@ -2052,8 +2052,8 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				integer3 := new(int64)
-				if !backendsItem2.Mode.Integer.IsUnknown() && !backendsItem2.Mode.Integer.IsNull() {
-					*integer3 = backendsItem2.Mode.Integer.ValueInt64()
+				if !r.Mtls.Backends[backendsIndex2].Mode.Integer.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Mode.Integer.IsNull() {
+					*integer3 = r.Mtls.Backends[backendsIndex2].Mode.Integer.ValueInt64()
 				} else {
 					integer3 = nil
 				}
@@ -2064,24 +2064,24 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			name4 := new(string)
-			if !backendsItem2.Name.IsUnknown() && !backendsItem2.Name.IsNull() {
-				*name4 = backendsItem2.Name.ValueString()
+			if !r.Mtls.Backends[backendsIndex2].Name.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Name.IsNull() {
+				*name4 = r.Mtls.Backends[backendsIndex2].Name.ValueString()
 			} else {
 				name4 = nil
 			}
 			var rootChain *shared.RootChain
-			if backendsItem2.RootChain != nil {
+			if r.Mtls.Backends[backendsIndex2].RootChain != nil {
 				var requestTimeout1 *shared.MeshItemRequestTimeout
-				if backendsItem2.RootChain.RequestTimeout != nil {
+				if r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout != nil {
 					nanos1 := new(int64)
-					if !backendsItem2.RootChain.RequestTimeout.Nanos.IsUnknown() && !backendsItem2.RootChain.RequestTimeout.Nanos.IsNull() {
-						*nanos1 = backendsItem2.RootChain.RequestTimeout.Nanos.ValueInt64()
+					if !r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Nanos.IsUnknown() && !r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Nanos.IsNull() {
+						*nanos1 = r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Nanos.ValueInt64()
 					} else {
 						nanos1 = nil
 					}
 					seconds1 := new(int64)
-					if !backendsItem2.RootChain.RequestTimeout.Seconds.IsUnknown() && !backendsItem2.RootChain.RequestTimeout.Seconds.IsNull() {
-						*seconds1 = backendsItem2.RootChain.RequestTimeout.Seconds.ValueInt64()
+					if !r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Seconds.IsUnknown() && !r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Seconds.IsNull() {
+						*seconds1 = r.Mtls.Backends[backendsIndex2].RootChain.RequestTimeout.Seconds.ValueInt64()
 					} else {
 						seconds1 = nil
 					}
@@ -2095,8 +2095,8 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			type2 := new(string)
-			if !backendsItem2.Type.IsUnknown() && !backendsItem2.Type.IsNull() {
-				*type2 = backendsItem2.Type.ValueString()
+			if !r.Mtls.Backends[backendsIndex2].Type.IsUnknown() && !r.Mtls.Backends[backendsIndex2].Type.IsNull() {
+				*type2 = r.Mtls.Backends[backendsIndex2].Type.ValueString()
 			} else {
 				type2 = nil
 			}
@@ -2175,32 +2175,32 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 		}
 	}
 	skipCreatingInitialPolicies := make([]string, 0, len(r.SkipCreatingInitialPolicies))
-	for _, skipCreatingInitialPoliciesItem := range r.SkipCreatingInitialPolicies {
-		skipCreatingInitialPolicies = append(skipCreatingInitialPolicies, skipCreatingInitialPoliciesItem.ValueString())
+	for skipCreatingInitialPoliciesIndex := range r.SkipCreatingInitialPolicies {
+		skipCreatingInitialPolicies = append(skipCreatingInitialPolicies, r.SkipCreatingInitialPolicies[skipCreatingInitialPoliciesIndex].ValueString())
 	}
 	var tracing *shared.Tracing
 	if r.Tracing != nil {
 		backends3 := make([]shared.MeshItemTracingBackends, 0, len(r.Tracing.Backends))
-		for _, backendsItem3 := range r.Tracing.Backends {
+		for backendsIndex3 := range r.Tracing.Backends {
 			var conf3 *shared.MeshItemTracingConf
-			if backendsItem3.Conf != nil {
+			if r.Tracing.Backends[backendsIndex3].Conf != nil {
 				var datadogTracingBackendConfig *shared.DatadogTracingBackendConfig
-				if backendsItem3.Conf.DatadogTracingBackendConfig != nil {
+				if r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig != nil {
 					address3 := new(string)
-					if !backendsItem3.Conf.DatadogTracingBackendConfig.Address.IsUnknown() && !backendsItem3.Conf.DatadogTracingBackendConfig.Address.IsNull() {
-						*address3 = backendsItem3.Conf.DatadogTracingBackendConfig.Address.ValueString()
+					if !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Address.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Address.IsNull() {
+						*address3 = r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Address.ValueString()
 					} else {
 						address3 = nil
 					}
 					port2 := new(int64)
-					if !backendsItem3.Conf.DatadogTracingBackendConfig.Port.IsUnknown() && !backendsItem3.Conf.DatadogTracingBackendConfig.Port.IsNull() {
-						*port2 = backendsItem3.Conf.DatadogTracingBackendConfig.Port.ValueInt64()
+					if !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Port.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Port.IsNull() {
+						*port2 = r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.Port.ValueInt64()
 					} else {
 						port2 = nil
 					}
 					splitService := new(bool)
-					if !backendsItem3.Conf.DatadogTracingBackendConfig.SplitService.IsUnknown() && !backendsItem3.Conf.DatadogTracingBackendConfig.SplitService.IsNull() {
-						*splitService = backendsItem3.Conf.DatadogTracingBackendConfig.SplitService.ValueBool()
+					if !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.SplitService.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.SplitService.IsNull() {
+						*splitService = r.Tracing.Backends[backendsIndex3].Conf.DatadogTracingBackendConfig.SplitService.ValueBool()
 					} else {
 						splitService = nil
 					}
@@ -2216,28 +2216,28 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 					}
 				}
 				var zipkinTracingBackendConfig *shared.ZipkinTracingBackendConfig
-				if backendsItem3.Conf.ZipkinTracingBackendConfig != nil {
+				if r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig != nil {
 					apiVersion := new(string)
-					if !backendsItem3.Conf.ZipkinTracingBackendConfig.APIVersion.IsUnknown() && !backendsItem3.Conf.ZipkinTracingBackendConfig.APIVersion.IsNull() {
-						*apiVersion = backendsItem3.Conf.ZipkinTracingBackendConfig.APIVersion.ValueString()
+					if !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.APIVersion.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.APIVersion.IsNull() {
+						*apiVersion = r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.APIVersion.ValueString()
 					} else {
 						apiVersion = nil
 					}
 					sharedSpanContext := new(bool)
-					if !backendsItem3.Conf.ZipkinTracingBackendConfig.SharedSpanContext.IsUnknown() && !backendsItem3.Conf.ZipkinTracingBackendConfig.SharedSpanContext.IsNull() {
-						*sharedSpanContext = backendsItem3.Conf.ZipkinTracingBackendConfig.SharedSpanContext.ValueBool()
+					if !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.SharedSpanContext.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.SharedSpanContext.IsNull() {
+						*sharedSpanContext = r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.SharedSpanContext.ValueBool()
 					} else {
 						sharedSpanContext = nil
 					}
 					traceId128bit := new(bool)
-					if !backendsItem3.Conf.ZipkinTracingBackendConfig.TraceId128bit.IsUnknown() && !backendsItem3.Conf.ZipkinTracingBackendConfig.TraceId128bit.IsNull() {
-						*traceId128bit = backendsItem3.Conf.ZipkinTracingBackendConfig.TraceId128bit.ValueBool()
+					if !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.TraceId128bit.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.TraceId128bit.IsNull() {
+						*traceId128bit = r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.TraceId128bit.ValueBool()
 					} else {
 						traceId128bit = nil
 					}
 					url := new(string)
-					if !backendsItem3.Conf.ZipkinTracingBackendConfig.URL.IsUnknown() && !backendsItem3.Conf.ZipkinTracingBackendConfig.URL.IsNull() {
-						*url = backendsItem3.Conf.ZipkinTracingBackendConfig.URL.ValueString()
+					if !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.URL.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.URL.IsNull() {
+						*url = r.Tracing.Backends[backendsIndex3].Conf.ZipkinTracingBackendConfig.URL.ValueString()
 					} else {
 						url = nil
 					}
@@ -2255,20 +2255,20 @@ func (r *MeshResourceModel) ToSharedMeshItem(ctx context.Context) (*shared.MeshI
 				}
 			}
 			name6 := new(string)
-			if !backendsItem3.Name.IsUnknown() && !backendsItem3.Name.IsNull() {
-				*name6 = backendsItem3.Name.ValueString()
+			if !r.Tracing.Backends[backendsIndex3].Name.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Name.IsNull() {
+				*name6 = r.Tracing.Backends[backendsIndex3].Name.ValueString()
 			} else {
 				name6 = nil
 			}
 			sampling := new(float64)
-			if !backendsItem3.Sampling.IsUnknown() && !backendsItem3.Sampling.IsNull() {
-				*sampling = backendsItem3.Sampling.ValueFloat64()
+			if !r.Tracing.Backends[backendsIndex3].Sampling.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Sampling.IsNull() {
+				*sampling = r.Tracing.Backends[backendsIndex3].Sampling.ValueFloat64()
 			} else {
 				sampling = nil
 			}
 			type3 := new(string)
-			if !backendsItem3.Type.IsUnknown() && !backendsItem3.Type.IsNull() {
-				*type3 = backendsItem3.Type.ValueString()
+			if !r.Tracing.Backends[backendsIndex3].Type.IsUnknown() && !r.Tracing.Backends[backendsIndex3].Type.IsNull() {
+				*type3 = r.Tracing.Backends[backendsIndex3].Type.ValueString()
 			} else {
 				type3 = nil
 			}

--- a/internal/provider/meshaccesslog_resource.go
+++ b/internal/provider/meshaccesslog_resource.go
@@ -25,7 +25,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -79,9 +78,6 @@ func (r *MeshAccessLogResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshAccessLogResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1398,7 +1391,10 @@ func (r *MeshAccessLogResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshaccesslog_resource_sdk.go
+++ b/internal/provider/meshaccesslog_resource_sdk.go
@@ -466,20 +466,20 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.From, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
-		backends := make([]shared.MeshAccessLogItemSpecFromBackends, 0, len(fromItem.Default.Backends))
-		for _, backendsItem := range fromItem.Default.Backends {
+	for fromIndex := range r.Spec.From {
+		backends := make([]shared.MeshAccessLogItemSpecFromBackends, 0, len(r.Spec.From[fromIndex].Default.Backends))
+		for backendsIndex := range r.Spec.From[fromIndex].Default.Backends {
 			var file *shared.File
-			if backendsItem.File != nil {
+			if r.Spec.From[fromIndex].Default.Backends[backendsIndex].File != nil {
 				var format *shared.Format
-				if backendsItem.File.Format != nil {
-					jsonVar := make([]shared.JSON, 0, len(backendsItem.File.Format.JSON))
-					for _, jsonItem := range backendsItem.File.Format.JSON {
+				if r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format != nil {
+					jsonVar := make([]shared.JSON, 0, len(r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.JSON))
+					for jsonIndex := range r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.JSON {
 						var key string
-						key = jsonItem.Key.ValueString()
+						key = r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.JSON[jsonIndex].Key.ValueString()
 
 						var value string
-						value = jsonItem.Value.ValueString()
+						value = r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.JSON[jsonIndex].Value.ValueString()
 
 						jsonVar = append(jsonVar, shared.JSON{
 							Key:   key,
@@ -487,18 +487,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues := new(bool)
-					if !backendsItem.File.Format.OmitEmptyValues.IsUnknown() && !backendsItem.File.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues = backendsItem.File.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.OmitEmptyValues.IsUnknown() && !r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues = r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues = nil
 					}
 					plain := new(string)
-					if !backendsItem.File.Format.Plain.IsUnknown() && !backendsItem.File.Format.Plain.IsNull() {
-						*plain = backendsItem.File.Format.Plain.ValueString()
+					if !r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.Plain.IsUnknown() && !r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.Plain.IsNull() {
+						*plain = r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.Plain.ValueString()
 					} else {
 						plain = nil
 					}
-					typeVar1 := shared.MeshAccessLogItemSpecFromType(backendsItem.File.Format.Type.ValueString())
+					typeVar1 := shared.MeshAccessLogItemSpecFromType(r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Format.Type.ValueString())
 					format = &shared.Format{
 						JSON:            jsonVar,
 						OmitEmptyValues: omitEmptyValues,
@@ -507,7 +507,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					}
 				}
 				var path string
-				path = backendsItem.File.Path.ValueString()
+				path = r.Spec.From[fromIndex].Default.Backends[backendsIndex].File.Path.ValueString()
 
 				file = &shared.File{
 					Format: format,
@@ -515,14 +515,14 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var openTelemetry *shared.MeshAccessLogItemSpecFromOpenTelemetry
-			if backendsItem.OpenTelemetry != nil {
-				attributes := make([]shared.Attributes, 0, len(backendsItem.OpenTelemetry.Attributes))
-				for _, attributesItem := range backendsItem.OpenTelemetry.Attributes {
+			if r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry != nil {
+				attributes := make([]shared.Attributes, 0, len(r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Attributes))
+				for attributesIndex := range r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Attributes {
 					var key1 string
-					key1 = attributesItem.Key.ValueString()
+					key1 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Attributes[attributesIndex].Key.ValueString()
 
 					var value1 string
-					value1 = attributesItem.Value.ValueString()
+					value1 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Attributes[attributesIndex].Value.ValueString()
 
 					attributes = append(attributes, shared.Attributes{
 						Key:   key1,
@@ -530,11 +530,11 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					})
 				}
 				var body interface{}
-				if !backendsItem.OpenTelemetry.Body.IsUnknown() && !backendsItem.OpenTelemetry.Body.IsNull() {
-					_ = json.Unmarshal([]byte(backendsItem.OpenTelemetry.Body.ValueString()), &body)
+				if !r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Body.IsUnknown() && !r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Body.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Body.ValueString()), &body)
 				}
 				var endpoint string
-				endpoint = backendsItem.OpenTelemetry.Endpoint.ValueString()
+				endpoint = r.Spec.From[fromIndex].Default.Backends[backendsIndex].OpenTelemetry.Endpoint.ValueString()
 
 				openTelemetry = &shared.MeshAccessLogItemSpecFromOpenTelemetry{
 					Attributes: attributes,
@@ -543,19 +543,19 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var tcp *shared.MeshAccessLogItemSpecFromTCP
-			if backendsItem.TCP != nil {
+			if r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP != nil {
 				var address string
-				address = backendsItem.TCP.Address.ValueString()
+				address = r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Address.ValueString()
 
 				var format1 *shared.MeshAccessLogItemFormat
-				if backendsItem.TCP.Format != nil {
-					jsonVar1 := make([]shared.MeshAccessLogItemJSON, 0, len(backendsItem.TCP.Format.JSON))
-					for _, jsonItem1 := range backendsItem.TCP.Format.JSON {
+				if r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format != nil {
+					jsonVar1 := make([]shared.MeshAccessLogItemJSON, 0, len(r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.JSON))
+					for jsonIndex1 := range r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.JSON {
 						var key2 string
-						key2 = jsonItem1.Key.ValueString()
+						key2 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.JSON[jsonIndex1].Key.ValueString()
 
 						var value2 string
-						value2 = jsonItem1.Value.ValueString()
+						value2 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.JSON[jsonIndex1].Value.ValueString()
 
 						jsonVar1 = append(jsonVar1, shared.MeshAccessLogItemJSON{
 							Key:   key2,
@@ -563,18 +563,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues1 := new(bool)
-					if !backendsItem.TCP.Format.OmitEmptyValues.IsUnknown() && !backendsItem.TCP.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues1 = backendsItem.TCP.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.OmitEmptyValues.IsUnknown() && !r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues1 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues1 = nil
 					}
 					plain1 := new(string)
-					if !backendsItem.TCP.Format.Plain.IsUnknown() && !backendsItem.TCP.Format.Plain.IsNull() {
-						*plain1 = backendsItem.TCP.Format.Plain.ValueString()
+					if !r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.Plain.IsUnknown() && !r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.Plain.IsNull() {
+						*plain1 = r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.Plain.ValueString()
 					} else {
 						plain1 = nil
 					}
-					typeVar2 := shared.MeshAccessLogItemSpecFromDefaultType(backendsItem.TCP.Format.Type.ValueString())
+					typeVar2 := shared.MeshAccessLogItemSpecFromDefaultType(r.Spec.From[fromIndex].Default.Backends[backendsIndex].TCP.Format.Type.ValueString())
 					format1 = &shared.MeshAccessLogItemFormat{
 						JSON:            jsonVar1,
 						OmitEmptyValues: omitEmptyValues1,
@@ -587,7 +587,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					Format:  format1,
 				}
 			}
-			type1 := shared.MeshAccessLogItemType(backendsItem.Type.ValueString())
+			type1 := shared.MeshAccessLogItemType(r.Spec.From[fromIndex].Default.Backends[backendsIndex].Type.ValueString())
 			backends = append(backends, shared.MeshAccessLogItemSpecFromBackends{
 				File:          file,
 				OpenTelemetry: openTelemetry,
@@ -598,46 +598,46 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 		defaultVar := shared.MeshAccessLogItemSpecFromDefault{
 			Backends: backends,
 		}
-		kind := shared.MeshAccessLogItemKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshAccessLogItemKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshAccessLogItemProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshAccessLogItemProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshAccessLogItemProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -657,20 +657,20 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 		})
 	}
 	rules := make([]shared.Rules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
-		backends1 := make([]shared.MeshAccessLogItemBackends, 0, len(rulesItem.Default.Backends))
-		for _, backendsItem1 := range rulesItem.Default.Backends {
+	for rulesIndex := range r.Spec.Rules {
+		backends1 := make([]shared.MeshAccessLogItemBackends, 0, len(r.Spec.Rules[rulesIndex].Default.Backends))
+		for backendsIndex1 := range r.Spec.Rules[rulesIndex].Default.Backends {
 			var file1 *shared.MeshAccessLogItemFile
-			if backendsItem1.File != nil {
+			if r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File != nil {
 				var format2 *shared.MeshAccessLogItemSpecFormat
-				if backendsItem1.File.Format != nil {
-					jsonVar2 := make([]shared.MeshAccessLogItemSpecJSON, 0, len(backendsItem1.File.Format.JSON))
-					for _, jsonItem2 := range backendsItem1.File.Format.JSON {
+				if r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format != nil {
+					jsonVar2 := make([]shared.MeshAccessLogItemSpecJSON, 0, len(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.JSON))
+					for jsonIndex2 := range r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.JSON {
 						var key3 string
-						key3 = jsonItem2.Key.ValueString()
+						key3 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.JSON[jsonIndex2].Key.ValueString()
 
 						var value3 string
-						value3 = jsonItem2.Value.ValueString()
+						value3 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.JSON[jsonIndex2].Value.ValueString()
 
 						jsonVar2 = append(jsonVar2, shared.MeshAccessLogItemSpecJSON{
 							Key:   key3,
@@ -678,18 +678,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues2 := new(bool)
-					if !backendsItem1.File.Format.OmitEmptyValues.IsUnknown() && !backendsItem1.File.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues2 = backendsItem1.File.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.OmitEmptyValues.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues2 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues2 = nil
 					}
 					plain2 := new(string)
-					if !backendsItem1.File.Format.Plain.IsUnknown() && !backendsItem1.File.Format.Plain.IsNull() {
-						*plain2 = backendsItem1.File.Format.Plain.ValueString()
+					if !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.Plain.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.Plain.IsNull() {
+						*plain2 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.Plain.ValueString()
 					} else {
 						plain2 = nil
 					}
-					typeVar3 := shared.MeshAccessLogItemSpecRulesType(backendsItem1.File.Format.Type.ValueString())
+					typeVar3 := shared.MeshAccessLogItemSpecRulesType(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Format.Type.ValueString())
 					format2 = &shared.MeshAccessLogItemSpecFormat{
 						JSON:            jsonVar2,
 						OmitEmptyValues: omitEmptyValues2,
@@ -698,7 +698,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					}
 				}
 				var path1 string
-				path1 = backendsItem1.File.Path.ValueString()
+				path1 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].File.Path.ValueString()
 
 				file1 = &shared.MeshAccessLogItemFile{
 					Format: format2,
@@ -706,14 +706,14 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var openTelemetry1 *shared.MeshAccessLogItemOpenTelemetry
-			if backendsItem1.OpenTelemetry != nil {
-				attributes1 := make([]shared.MeshAccessLogItemAttributes, 0, len(backendsItem1.OpenTelemetry.Attributes))
-				for _, attributesItem1 := range backendsItem1.OpenTelemetry.Attributes {
+			if r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry != nil {
+				attributes1 := make([]shared.MeshAccessLogItemAttributes, 0, len(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Attributes))
+				for attributesIndex1 := range r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Attributes {
 					var key4 string
-					key4 = attributesItem1.Key.ValueString()
+					key4 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Attributes[attributesIndex1].Key.ValueString()
 
 					var value4 string
-					value4 = attributesItem1.Value.ValueString()
+					value4 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Attributes[attributesIndex1].Value.ValueString()
 
 					attributes1 = append(attributes1, shared.MeshAccessLogItemAttributes{
 						Key:   key4,
@@ -721,11 +721,11 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					})
 				}
 				var body1 interface{}
-				if !backendsItem1.OpenTelemetry.Body.IsUnknown() && !backendsItem1.OpenTelemetry.Body.IsNull() {
-					_ = json.Unmarshal([]byte(backendsItem1.OpenTelemetry.Body.ValueString()), &body1)
+				if !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Body.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Body.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Body.ValueString()), &body1)
 				}
 				var endpoint1 string
-				endpoint1 = backendsItem1.OpenTelemetry.Endpoint.ValueString()
+				endpoint1 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].OpenTelemetry.Endpoint.ValueString()
 
 				openTelemetry1 = &shared.MeshAccessLogItemOpenTelemetry{
 					Attributes: attributes1,
@@ -734,19 +734,19 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var tcp1 *shared.MeshAccessLogItemTCP
-			if backendsItem1.TCP != nil {
+			if r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP != nil {
 				var address1 string
-				address1 = backendsItem1.TCP.Address.ValueString()
+				address1 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Address.ValueString()
 
 				var format3 *shared.MeshAccessLogItemSpecRulesFormat
-				if backendsItem1.TCP.Format != nil {
-					jsonVar3 := make([]shared.MeshAccessLogItemSpecRulesJSON, 0, len(backendsItem1.TCP.Format.JSON))
-					for _, jsonItem3 := range backendsItem1.TCP.Format.JSON {
+				if r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format != nil {
+					jsonVar3 := make([]shared.MeshAccessLogItemSpecRulesJSON, 0, len(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.JSON))
+					for jsonIndex3 := range r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.JSON {
 						var key5 string
-						key5 = jsonItem3.Key.ValueString()
+						key5 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.JSON[jsonIndex3].Key.ValueString()
 
 						var value5 string
-						value5 = jsonItem3.Value.ValueString()
+						value5 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.JSON[jsonIndex3].Value.ValueString()
 
 						jsonVar3 = append(jsonVar3, shared.MeshAccessLogItemSpecRulesJSON{
 							Key:   key5,
@@ -754,18 +754,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues3 := new(bool)
-					if !backendsItem1.TCP.Format.OmitEmptyValues.IsUnknown() && !backendsItem1.TCP.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues3 = backendsItem1.TCP.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.OmitEmptyValues.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues3 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues3 = nil
 					}
 					plain3 := new(string)
-					if !backendsItem1.TCP.Format.Plain.IsUnknown() && !backendsItem1.TCP.Format.Plain.IsNull() {
-						*plain3 = backendsItem1.TCP.Format.Plain.ValueString()
+					if !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.Plain.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.Plain.IsNull() {
+						*plain3 = r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.Plain.ValueString()
 					} else {
 						plain3 = nil
 					}
-					typeVar4 := shared.MeshAccessLogItemSpecRulesDefaultType(backendsItem1.TCP.Format.Type.ValueString())
+					typeVar4 := shared.MeshAccessLogItemSpecRulesDefaultType(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].TCP.Format.Type.ValueString())
 					format3 = &shared.MeshAccessLogItemSpecRulesFormat{
 						JSON:            jsonVar3,
 						OmitEmptyValues: omitEmptyValues3,
@@ -778,7 +778,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					Format:  format3,
 				}
 			}
-			type2 := shared.MeshAccessLogItemSpecType(backendsItem1.Type.ValueString())
+			type2 := shared.MeshAccessLogItemSpecType(r.Spec.Rules[rulesIndex].Default.Backends[backendsIndex1].Type.ValueString())
 			backends1 = append(backends1, shared.MeshAccessLogItemBackends{
 				File:          file1,
 				OpenTelemetry: openTelemetry1,
@@ -797,9 +797,9 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.Kind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -832,9 +832,9 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -850,20 +850,20 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 		}
 	}
 	to := make([]shared.To, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
-		backends2 := make([]shared.MeshAccessLogItemSpecBackends, 0, len(toItem.Default.Backends))
-		for _, backendsItem2 := range toItem.Default.Backends {
+	for toIndex := range r.Spec.To {
+		backends2 := make([]shared.MeshAccessLogItemSpecBackends, 0, len(r.Spec.To[toIndex].Default.Backends))
+		for backendsIndex2 := range r.Spec.To[toIndex].Default.Backends {
 			var file2 *shared.MeshAccessLogItemSpecFile
-			if backendsItem2.File != nil {
+			if r.Spec.To[toIndex].Default.Backends[backendsIndex2].File != nil {
 				var format4 *shared.MeshAccessLogItemSpecToFormat
-				if backendsItem2.File.Format != nil {
-					jsonVar4 := make([]shared.MeshAccessLogItemSpecToJSON, 0, len(backendsItem2.File.Format.JSON))
-					for _, jsonItem4 := range backendsItem2.File.Format.JSON {
+				if r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format != nil {
+					jsonVar4 := make([]shared.MeshAccessLogItemSpecToJSON, 0, len(r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.JSON))
+					for jsonIndex4 := range r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.JSON {
 						var key6 string
-						key6 = jsonItem4.Key.ValueString()
+						key6 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.JSON[jsonIndex4].Key.ValueString()
 
 						var value6 string
-						value6 = jsonItem4.Value.ValueString()
+						value6 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.JSON[jsonIndex4].Value.ValueString()
 
 						jsonVar4 = append(jsonVar4, shared.MeshAccessLogItemSpecToJSON{
 							Key:   key6,
@@ -871,18 +871,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues4 := new(bool)
-					if !backendsItem2.File.Format.OmitEmptyValues.IsUnknown() && !backendsItem2.File.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues4 = backendsItem2.File.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.OmitEmptyValues.IsUnknown() && !r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues4 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues4 = nil
 					}
 					plain4 := new(string)
-					if !backendsItem2.File.Format.Plain.IsUnknown() && !backendsItem2.File.Format.Plain.IsNull() {
-						*plain4 = backendsItem2.File.Format.Plain.ValueString()
+					if !r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.Plain.IsUnknown() && !r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.Plain.IsNull() {
+						*plain4 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.Plain.ValueString()
 					} else {
 						plain4 = nil
 					}
-					typeVar5 := shared.MeshAccessLogItemSpecToDefaultBackendsType(backendsItem2.File.Format.Type.ValueString())
+					typeVar5 := shared.MeshAccessLogItemSpecToDefaultBackendsType(r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Format.Type.ValueString())
 					format4 = &shared.MeshAccessLogItemSpecToFormat{
 						JSON:            jsonVar4,
 						OmitEmptyValues: omitEmptyValues4,
@@ -891,7 +891,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					}
 				}
 				var path2 string
-				path2 = backendsItem2.File.Path.ValueString()
+				path2 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].File.Path.ValueString()
 
 				file2 = &shared.MeshAccessLogItemSpecFile{
 					Format: format4,
@@ -899,14 +899,14 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var openTelemetry2 *shared.MeshAccessLogItemSpecOpenTelemetry
-			if backendsItem2.OpenTelemetry != nil {
-				attributes2 := make([]shared.MeshAccessLogItemSpecAttributes, 0, len(backendsItem2.OpenTelemetry.Attributes))
-				for _, attributesItem2 := range backendsItem2.OpenTelemetry.Attributes {
+			if r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry != nil {
+				attributes2 := make([]shared.MeshAccessLogItemSpecAttributes, 0, len(r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Attributes))
+				for attributesIndex2 := range r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Attributes {
 					var key7 string
-					key7 = attributesItem2.Key.ValueString()
+					key7 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Attributes[attributesIndex2].Key.ValueString()
 
 					var value7 string
-					value7 = attributesItem2.Value.ValueString()
+					value7 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Attributes[attributesIndex2].Value.ValueString()
 
 					attributes2 = append(attributes2, shared.MeshAccessLogItemSpecAttributes{
 						Key:   key7,
@@ -914,11 +914,11 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					})
 				}
 				var body2 interface{}
-				if !backendsItem2.OpenTelemetry.Body.IsUnknown() && !backendsItem2.OpenTelemetry.Body.IsNull() {
-					_ = json.Unmarshal([]byte(backendsItem2.OpenTelemetry.Body.ValueString()), &body2)
+				if !r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Body.IsUnknown() && !r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Body.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Body.ValueString()), &body2)
 				}
 				var endpoint2 string
-				endpoint2 = backendsItem2.OpenTelemetry.Endpoint.ValueString()
+				endpoint2 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].OpenTelemetry.Endpoint.ValueString()
 
 				openTelemetry2 = &shared.MeshAccessLogItemSpecOpenTelemetry{
 					Attributes: attributes2,
@@ -927,19 +927,19 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 				}
 			}
 			var tcp2 *shared.MeshAccessLogItemSpecTCP
-			if backendsItem2.TCP != nil {
+			if r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP != nil {
 				var address2 string
-				address2 = backendsItem2.TCP.Address.ValueString()
+				address2 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Address.ValueString()
 
 				var format5 *shared.MeshAccessLogItemSpecToDefaultFormat
-				if backendsItem2.TCP.Format != nil {
-					jsonVar5 := make([]shared.MeshAccessLogItemSpecToDefaultJSON, 0, len(backendsItem2.TCP.Format.JSON))
-					for _, jsonItem5 := range backendsItem2.TCP.Format.JSON {
+				if r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format != nil {
+					jsonVar5 := make([]shared.MeshAccessLogItemSpecToDefaultJSON, 0, len(r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.JSON))
+					for jsonIndex5 := range r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.JSON {
 						var key8 string
-						key8 = jsonItem5.Key.ValueString()
+						key8 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.JSON[jsonIndex5].Key.ValueString()
 
 						var value8 string
-						value8 = jsonItem5.Value.ValueString()
+						value8 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.JSON[jsonIndex5].Value.ValueString()
 
 						jsonVar5 = append(jsonVar5, shared.MeshAccessLogItemSpecToDefaultJSON{
 							Key:   key8,
@@ -947,18 +947,18 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 						})
 					}
 					omitEmptyValues5 := new(bool)
-					if !backendsItem2.TCP.Format.OmitEmptyValues.IsUnknown() && !backendsItem2.TCP.Format.OmitEmptyValues.IsNull() {
-						*omitEmptyValues5 = backendsItem2.TCP.Format.OmitEmptyValues.ValueBool()
+					if !r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.OmitEmptyValues.IsUnknown() && !r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.OmitEmptyValues.IsNull() {
+						*omitEmptyValues5 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.OmitEmptyValues.ValueBool()
 					} else {
 						omitEmptyValues5 = nil
 					}
 					plain5 := new(string)
-					if !backendsItem2.TCP.Format.Plain.IsUnknown() && !backendsItem2.TCP.Format.Plain.IsNull() {
-						*plain5 = backendsItem2.TCP.Format.Plain.ValueString()
+					if !r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.Plain.IsUnknown() && !r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.Plain.IsNull() {
+						*plain5 = r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.Plain.ValueString()
 					} else {
 						plain5 = nil
 					}
-					typeVar6 := shared.MeshAccessLogItemSpecToDefaultType(backendsItem2.TCP.Format.Type.ValueString())
+					typeVar6 := shared.MeshAccessLogItemSpecToDefaultType(r.Spec.To[toIndex].Default.Backends[backendsIndex2].TCP.Format.Type.ValueString())
 					format5 = &shared.MeshAccessLogItemSpecToDefaultFormat{
 						JSON:            jsonVar5,
 						OmitEmptyValues: omitEmptyValues5,
@@ -971,7 +971,7 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 					Format:  format5,
 				}
 			}
-			type3 := shared.MeshAccessLogItemSpecToType(backendsItem2.Type.ValueString())
+			type3 := shared.MeshAccessLogItemSpecToType(r.Spec.To[toIndex].Default.Backends[backendsIndex2].Type.ValueString())
 			backends2 = append(backends2, shared.MeshAccessLogItemSpecBackends{
 				File:          file2,
 				OpenTelemetry: openTelemetry2,
@@ -982,46 +982,46 @@ func (r *MeshAccessLogResourceModel) ToSharedMeshAccessLogItemInput(ctx context.
 		default2 := shared.MeshAccessLogItemSpecDefault{
 			Backends: backends2,
 		}
-		kind2 := shared.MeshAccessLogItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshAccessLogItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name3 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name3 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshAccessLogItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshAccessLogItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshAccessLogItemSpecProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshcircuitbreaker_resource.go
+++ b/internal/provider/meshcircuitbreaker_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -77,9 +76,6 @@ func (r *MeshCircuitBreakerResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +100,6 @@ func (r *MeshCircuitBreakerResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1524,7 +1517,10 @@ func (r *MeshCircuitBreakerResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshcircuitbreaker_resource_sdk.go
+++ b/internal/provider/meshcircuitbreaker_resource_sdk.go
@@ -470,38 +470,38 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshCircuitBreakerItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshCircuitBreakerItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			var connectionLimits *shared.ConnectionLimits
-			if fromItem.Default.ConnectionLimits != nil {
+			if r.Spec.From[fromIndex].Default.ConnectionLimits != nil {
 				maxConnectionPools := new(int)
-				if !fromItem.Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !fromItem.Default.ConnectionLimits.MaxConnectionPools.IsNull() {
-					*maxConnectionPools = int(fromItem.Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnectionPools.IsNull() {
+					*maxConnectionPools = int(r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
 				} else {
 					maxConnectionPools = nil
 				}
 				maxConnections := new(int)
-				if !fromItem.Default.ConnectionLimits.MaxConnections.IsUnknown() && !fromItem.Default.ConnectionLimits.MaxConnections.IsNull() {
-					*maxConnections = int(fromItem.Default.ConnectionLimits.MaxConnections.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnections.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnections.IsNull() {
+					*maxConnections = int(r.Spec.From[fromIndex].Default.ConnectionLimits.MaxConnections.ValueInt32())
 				} else {
 					maxConnections = nil
 				}
 				maxPendingRequests := new(int)
-				if !fromItem.Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !fromItem.Default.ConnectionLimits.MaxPendingRequests.IsNull() {
-					*maxPendingRequests = int(fromItem.Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxPendingRequests.IsNull() {
+					*maxPendingRequests = int(r.Spec.From[fromIndex].Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
 				} else {
 					maxPendingRequests = nil
 				}
 				maxRequests := new(int)
-				if !fromItem.Default.ConnectionLimits.MaxRequests.IsUnknown() && !fromItem.Default.ConnectionLimits.MaxRequests.IsNull() {
-					*maxRequests = int(fromItem.Default.ConnectionLimits.MaxRequests.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRequests.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRequests.IsNull() {
+					*maxRequests = int(r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRequests.ValueInt32())
 				} else {
 					maxRequests = nil
 				}
 				maxRetries := new(int)
-				if !fromItem.Default.ConnectionLimits.MaxRetries.IsUnknown() && !fromItem.Default.ConnectionLimits.MaxRetries.IsNull() {
-					*maxRetries = int(fromItem.Default.ConnectionLimits.MaxRetries.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRetries.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRetries.IsNull() {
+					*maxRetries = int(r.Spec.From[fromIndex].Default.ConnectionLimits.MaxRetries.ValueInt32())
 				} else {
 					maxRetries = nil
 				}
@@ -514,32 +514,32 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 				}
 			}
 			var outlierDetection *shared.OutlierDetection
-			if fromItem.Default.OutlierDetection != nil {
+			if r.Spec.From[fromIndex].Default.OutlierDetection != nil {
 				baseEjectionTime := new(string)
-				if !fromItem.Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !fromItem.Default.OutlierDetection.BaseEjectionTime.IsNull() {
-					*baseEjectionTime = fromItem.Default.OutlierDetection.BaseEjectionTime.ValueString()
+				if !r.Spec.From[fromIndex].Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.BaseEjectionTime.IsNull() {
+					*baseEjectionTime = r.Spec.From[fromIndex].Default.OutlierDetection.BaseEjectionTime.ValueString()
 				} else {
 					baseEjectionTime = nil
 				}
 				var detectors *shared.Detectors
-				if fromItem.Default.OutlierDetection.Detectors != nil {
+				if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors != nil {
 					var failurePercentage *shared.FailurePercentage
-					if fromItem.Default.OutlierDetection.Detectors.FailurePercentage != nil {
+					if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage != nil {
 						minimumHosts := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
-							*minimumHosts = int(fromItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
+							*minimumHosts = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts = nil
 						}
 						requestVolume := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
-							*requestVolume = int(fromItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
+							*requestVolume = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
 						} else {
 							requestVolume = nil
 						}
 						threshold := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
-							*threshold = int(fromItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
+							*threshold = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
 						} else {
 							threshold = nil
 						}
@@ -550,10 +550,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var gatewayFailures *shared.GatewayFailures
-					if fromItem.Default.OutlierDetection.Detectors.GatewayFailures != nil {
+					if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.GatewayFailures != nil {
 						consecutive := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
-							*consecutive = int(fromItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
+							*consecutive = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive = nil
 						}
@@ -562,10 +562,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var localOriginFailures *shared.LocalOriginFailures
-					if fromItem.Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
+					if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
 						consecutive1 := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
-							*consecutive1 = int(fromItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
+							*consecutive1 = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive1 = nil
 						}
@@ -574,24 +574,24 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var successRate *shared.SuccessRate
-					if fromItem.Default.OutlierDetection.Detectors.SuccessRate != nil {
+					if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate != nil {
 						minimumHosts1 := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
-							*minimumHosts1 = int(fromItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
+							*minimumHosts1 = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts1 = nil
 						}
 						requestVolume1 := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
-							*requestVolume1 = int(fromItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
+							*requestVolume1 = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
 						} else {
 							requestVolume1 = nil
 						}
 						var standardDeviationFactor *shared.StandardDeviationFactor
-						if fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
+						if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
 							integer := new(int64)
-							if !fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
-								*integer = fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
+							if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
+								*integer = r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
 							} else {
 								integer = nil
 							}
@@ -601,8 +601,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 								}
 							}
 							str := new(string)
-							if !fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
-								*str = fromItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
+							if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
+								*str = r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
 							} else {
 								str = nil
 							}
@@ -619,10 +619,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var totalFailures *shared.TotalFailures
-					if fromItem.Default.OutlierDetection.Detectors.TotalFailures != nil {
+					if r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.TotalFailures != nil {
 						consecutive2 := new(int)
-						if !fromItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !fromItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
-							*consecutive2 = int(fromItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
+							*consecutive2 = int(r.Spec.From[fromIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive2 = nil
 						}
@@ -639,16 +639,16 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				disabled := new(bool)
-				if !fromItem.Default.OutlierDetection.Disabled.IsUnknown() && !fromItem.Default.OutlierDetection.Disabled.IsNull() {
-					*disabled = fromItem.Default.OutlierDetection.Disabled.ValueBool()
+				if !r.Spec.From[fromIndex].Default.OutlierDetection.Disabled.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Disabled.IsNull() {
+					*disabled = r.Spec.From[fromIndex].Default.OutlierDetection.Disabled.ValueBool()
 				} else {
 					disabled = nil
 				}
 				var healthyPanicThreshold *shared.MeshCircuitBreakerItemSpecFromHealthyPanicThreshold
-				if fromItem.Default.OutlierDetection.HealthyPanicThreshold != nil {
+				if r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold != nil {
 					integer1 := new(int64)
-					if !fromItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !fromItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
-						*integer1 = fromItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
+					if !r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
+						*integer1 = r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
 					} else {
 						integer1 = nil
 					}
@@ -658,8 +658,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					str1 := new(string)
-					if !fromItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !fromItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
-						*str1 = fromItem.Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
+					if !r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
+						*str1 = r.Spec.From[fromIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
 					} else {
 						str1 = nil
 					}
@@ -670,20 +670,20 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				interval := new(string)
-				if !fromItem.Default.OutlierDetection.Interval.IsUnknown() && !fromItem.Default.OutlierDetection.Interval.IsNull() {
-					*interval = fromItem.Default.OutlierDetection.Interval.ValueString()
+				if !r.Spec.From[fromIndex].Default.OutlierDetection.Interval.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.Interval.IsNull() {
+					*interval = r.Spec.From[fromIndex].Default.OutlierDetection.Interval.ValueString()
 				} else {
 					interval = nil
 				}
 				maxEjectionPercent := new(int)
-				if !fromItem.Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !fromItem.Default.OutlierDetection.MaxEjectionPercent.IsNull() {
-					*maxEjectionPercent = int(fromItem.Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.MaxEjectionPercent.IsNull() {
+					*maxEjectionPercent = int(r.Spec.From[fromIndex].Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
 				} else {
 					maxEjectionPercent = nil
 				}
 				splitExternalAndLocalErrors := new(bool)
-				if !fromItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !fromItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
-					*splitExternalAndLocalErrors = fromItem.Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
+				if !r.Spec.From[fromIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !r.Spec.From[fromIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
+					*splitExternalAndLocalErrors = r.Spec.From[fromIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
 				} else {
 					splitExternalAndLocalErrors = nil
 				}
@@ -702,46 +702,46 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 				OutlierDetection: outlierDetection,
 			}
 		}
-		kind := shared.MeshCircuitBreakerItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshCircuitBreakerItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshCircuitBreakerItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshCircuitBreakerItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshCircuitBreakerItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -761,38 +761,38 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 		})
 	}
 	rules := make([]shared.MeshCircuitBreakerItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
+	for rulesIndex := range r.Spec.Rules {
 		var default1 *shared.MeshCircuitBreakerItemSpecDefault
-		if rulesItem.Default != nil {
+		if r.Spec.Rules[rulesIndex].Default != nil {
 			var connectionLimits1 *shared.MeshCircuitBreakerItemConnectionLimits
-			if rulesItem.Default.ConnectionLimits != nil {
+			if r.Spec.Rules[rulesIndex].Default.ConnectionLimits != nil {
 				maxConnectionPools1 := new(int)
-				if !rulesItem.Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !rulesItem.Default.ConnectionLimits.MaxConnectionPools.IsNull() {
-					*maxConnectionPools1 = int(rulesItem.Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnectionPools.IsNull() {
+					*maxConnectionPools1 = int(r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
 				} else {
 					maxConnectionPools1 = nil
 				}
 				maxConnections1 := new(int)
-				if !rulesItem.Default.ConnectionLimits.MaxConnections.IsUnknown() && !rulesItem.Default.ConnectionLimits.MaxConnections.IsNull() {
-					*maxConnections1 = int(rulesItem.Default.ConnectionLimits.MaxConnections.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnections.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnections.IsNull() {
+					*maxConnections1 = int(r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxConnections.ValueInt32())
 				} else {
 					maxConnections1 = nil
 				}
 				maxPendingRequests1 := new(int)
-				if !rulesItem.Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !rulesItem.Default.ConnectionLimits.MaxPendingRequests.IsNull() {
-					*maxPendingRequests1 = int(rulesItem.Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxPendingRequests.IsNull() {
+					*maxPendingRequests1 = int(r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
 				} else {
 					maxPendingRequests1 = nil
 				}
 				maxRequests1 := new(int)
-				if !rulesItem.Default.ConnectionLimits.MaxRequests.IsUnknown() && !rulesItem.Default.ConnectionLimits.MaxRequests.IsNull() {
-					*maxRequests1 = int(rulesItem.Default.ConnectionLimits.MaxRequests.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRequests.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRequests.IsNull() {
+					*maxRequests1 = int(r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRequests.ValueInt32())
 				} else {
 					maxRequests1 = nil
 				}
 				maxRetries1 := new(int)
-				if !rulesItem.Default.ConnectionLimits.MaxRetries.IsUnknown() && !rulesItem.Default.ConnectionLimits.MaxRetries.IsNull() {
-					*maxRetries1 = int(rulesItem.Default.ConnectionLimits.MaxRetries.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRetries.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRetries.IsNull() {
+					*maxRetries1 = int(r.Spec.Rules[rulesIndex].Default.ConnectionLimits.MaxRetries.ValueInt32())
 				} else {
 					maxRetries1 = nil
 				}
@@ -805,32 +805,32 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 				}
 			}
 			var outlierDetection1 *shared.MeshCircuitBreakerItemOutlierDetection
-			if rulesItem.Default.OutlierDetection != nil {
+			if r.Spec.Rules[rulesIndex].Default.OutlierDetection != nil {
 				baseEjectionTime1 := new(string)
-				if !rulesItem.Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !rulesItem.Default.OutlierDetection.BaseEjectionTime.IsNull() {
-					*baseEjectionTime1 = rulesItem.Default.OutlierDetection.BaseEjectionTime.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.BaseEjectionTime.IsNull() {
+					*baseEjectionTime1 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.BaseEjectionTime.ValueString()
 				} else {
 					baseEjectionTime1 = nil
 				}
 				var detectors1 *shared.MeshCircuitBreakerItemDetectors
-				if rulesItem.Default.OutlierDetection.Detectors != nil {
+				if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors != nil {
 					var failurePercentage1 *shared.MeshCircuitBreakerItemFailurePercentage
-					if rulesItem.Default.OutlierDetection.Detectors.FailurePercentage != nil {
+					if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage != nil {
 						minimumHosts2 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
-							*minimumHosts2 = int(rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
+							*minimumHosts2 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts2 = nil
 						}
 						requestVolume2 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
-							*requestVolume2 = int(rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
+							*requestVolume2 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
 						} else {
 							requestVolume2 = nil
 						}
 						threshold1 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
-							*threshold1 = int(rulesItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
+							*threshold1 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
 						} else {
 							threshold1 = nil
 						}
@@ -841,10 +841,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var gatewayFailures1 *shared.MeshCircuitBreakerItemGatewayFailures
-					if rulesItem.Default.OutlierDetection.Detectors.GatewayFailures != nil {
+					if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.GatewayFailures != nil {
 						consecutive3 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
-							*consecutive3 = int(rulesItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
+							*consecutive3 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive3 = nil
 						}
@@ -853,10 +853,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var localOriginFailures1 *shared.MeshCircuitBreakerItemLocalOriginFailures
-					if rulesItem.Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
+					if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
 						consecutive4 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
-							*consecutive4 = int(rulesItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
+							*consecutive4 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive4 = nil
 						}
@@ -865,24 +865,24 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var successRate1 *shared.MeshCircuitBreakerItemSuccessRate
-					if rulesItem.Default.OutlierDetection.Detectors.SuccessRate != nil {
+					if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate != nil {
 						minimumHosts3 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
-							*minimumHosts3 = int(rulesItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
+							*minimumHosts3 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts3 = nil
 						}
 						requestVolume3 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
-							*requestVolume3 = int(rulesItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
+							*requestVolume3 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
 						} else {
 							requestVolume3 = nil
 						}
 						var standardDeviationFactor1 *shared.MeshCircuitBreakerItemStandardDeviationFactor
-						if rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
+						if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
 							integer2 := new(int64)
-							if !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
-								*integer2 = rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
+							if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
+								*integer2 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
 							} else {
 								integer2 = nil
 							}
@@ -892,8 +892,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 								}
 							}
 							str2 := new(string)
-							if !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
-								*str2 = rulesItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
+							if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
+								*str2 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
 							} else {
 								str2 = nil
 							}
@@ -910,10 +910,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var totalFailures1 *shared.MeshCircuitBreakerItemTotalFailures
-					if rulesItem.Default.OutlierDetection.Detectors.TotalFailures != nil {
+					if r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.TotalFailures != nil {
 						consecutive5 := new(int)
-						if !rulesItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !rulesItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
-							*consecutive5 = int(rulesItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
+							*consecutive5 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive5 = nil
 						}
@@ -930,16 +930,16 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				disabled1 := new(bool)
-				if !rulesItem.Default.OutlierDetection.Disabled.IsUnknown() && !rulesItem.Default.OutlierDetection.Disabled.IsNull() {
-					*disabled1 = rulesItem.Default.OutlierDetection.Disabled.ValueBool()
+				if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Disabled.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Disabled.IsNull() {
+					*disabled1 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.Disabled.ValueBool()
 				} else {
 					disabled1 = nil
 				}
 				var healthyPanicThreshold1 *shared.MeshCircuitBreakerItemHealthyPanicThreshold
-				if rulesItem.Default.OutlierDetection.HealthyPanicThreshold != nil {
+				if r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold != nil {
 					integer3 := new(int64)
-					if !rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
-						*integer3 = rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
+					if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
+						*integer3 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
 					} else {
 						integer3 = nil
 					}
@@ -949,8 +949,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					str3 := new(string)
-					if !rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
-						*str3 = rulesItem.Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
+					if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
+						*str3 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
 					} else {
 						str3 = nil
 					}
@@ -961,20 +961,20 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				interval1 := new(string)
-				if !rulesItem.Default.OutlierDetection.Interval.IsUnknown() && !rulesItem.Default.OutlierDetection.Interval.IsNull() {
-					*interval1 = rulesItem.Default.OutlierDetection.Interval.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Interval.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.Interval.IsNull() {
+					*interval1 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.Interval.ValueString()
 				} else {
 					interval1 = nil
 				}
 				maxEjectionPercent1 := new(int)
-				if !rulesItem.Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !rulesItem.Default.OutlierDetection.MaxEjectionPercent.IsNull() {
-					*maxEjectionPercent1 = int(rulesItem.Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
+				if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.MaxEjectionPercent.IsNull() {
+					*maxEjectionPercent1 = int(r.Spec.Rules[rulesIndex].Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
 				} else {
 					maxEjectionPercent1 = nil
 				}
 				splitExternalAndLocalErrors1 := new(bool)
-				if !rulesItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !rulesItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
-					*splitExternalAndLocalErrors1 = rulesItem.Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
+				if !r.Spec.Rules[rulesIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
+					*splitExternalAndLocalErrors1 = r.Spec.Rules[rulesIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
 				} else {
 					splitExternalAndLocalErrors1 = nil
 				}
@@ -1001,9 +1001,9 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshCircuitBreakerItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -1036,9 +1036,9 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -1054,38 +1054,38 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 		}
 	}
 	to := make([]shared.MeshCircuitBreakerItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var default2 *shared.MeshCircuitBreakerItemSpecToDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			var connectionLimits2 *shared.MeshCircuitBreakerItemSpecConnectionLimits
-			if toItem.Default.ConnectionLimits != nil {
+			if r.Spec.To[toIndex].Default.ConnectionLimits != nil {
 				maxConnectionPools2 := new(int)
-				if !toItem.Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !toItem.Default.ConnectionLimits.MaxConnectionPools.IsNull() {
-					*maxConnectionPools2 = int(toItem.Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
+				if !r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnectionPools.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnectionPools.IsNull() {
+					*maxConnectionPools2 = int(r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnectionPools.ValueInt32())
 				} else {
 					maxConnectionPools2 = nil
 				}
 				maxConnections2 := new(int)
-				if !toItem.Default.ConnectionLimits.MaxConnections.IsUnknown() && !toItem.Default.ConnectionLimits.MaxConnections.IsNull() {
-					*maxConnections2 = int(toItem.Default.ConnectionLimits.MaxConnections.ValueInt32())
+				if !r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnections.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnections.IsNull() {
+					*maxConnections2 = int(r.Spec.To[toIndex].Default.ConnectionLimits.MaxConnections.ValueInt32())
 				} else {
 					maxConnections2 = nil
 				}
 				maxPendingRequests2 := new(int)
-				if !toItem.Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !toItem.Default.ConnectionLimits.MaxPendingRequests.IsNull() {
-					*maxPendingRequests2 = int(toItem.Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
+				if !r.Spec.To[toIndex].Default.ConnectionLimits.MaxPendingRequests.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionLimits.MaxPendingRequests.IsNull() {
+					*maxPendingRequests2 = int(r.Spec.To[toIndex].Default.ConnectionLimits.MaxPendingRequests.ValueInt32())
 				} else {
 					maxPendingRequests2 = nil
 				}
 				maxRequests2 := new(int)
-				if !toItem.Default.ConnectionLimits.MaxRequests.IsUnknown() && !toItem.Default.ConnectionLimits.MaxRequests.IsNull() {
-					*maxRequests2 = int(toItem.Default.ConnectionLimits.MaxRequests.ValueInt32())
+				if !r.Spec.To[toIndex].Default.ConnectionLimits.MaxRequests.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionLimits.MaxRequests.IsNull() {
+					*maxRequests2 = int(r.Spec.To[toIndex].Default.ConnectionLimits.MaxRequests.ValueInt32())
 				} else {
 					maxRequests2 = nil
 				}
 				maxRetries2 := new(int)
-				if !toItem.Default.ConnectionLimits.MaxRetries.IsUnknown() && !toItem.Default.ConnectionLimits.MaxRetries.IsNull() {
-					*maxRetries2 = int(toItem.Default.ConnectionLimits.MaxRetries.ValueInt32())
+				if !r.Spec.To[toIndex].Default.ConnectionLimits.MaxRetries.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionLimits.MaxRetries.IsNull() {
+					*maxRetries2 = int(r.Spec.To[toIndex].Default.ConnectionLimits.MaxRetries.ValueInt32())
 				} else {
 					maxRetries2 = nil
 				}
@@ -1098,32 +1098,32 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 				}
 			}
 			var outlierDetection2 *shared.MeshCircuitBreakerItemSpecOutlierDetection
-			if toItem.Default.OutlierDetection != nil {
+			if r.Spec.To[toIndex].Default.OutlierDetection != nil {
 				baseEjectionTime2 := new(string)
-				if !toItem.Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !toItem.Default.OutlierDetection.BaseEjectionTime.IsNull() {
-					*baseEjectionTime2 = toItem.Default.OutlierDetection.BaseEjectionTime.ValueString()
+				if !r.Spec.To[toIndex].Default.OutlierDetection.BaseEjectionTime.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.BaseEjectionTime.IsNull() {
+					*baseEjectionTime2 = r.Spec.To[toIndex].Default.OutlierDetection.BaseEjectionTime.ValueString()
 				} else {
 					baseEjectionTime2 = nil
 				}
 				var detectors2 *shared.MeshCircuitBreakerItemSpecDetectors
-				if toItem.Default.OutlierDetection.Detectors != nil {
+				if r.Spec.To[toIndex].Default.OutlierDetection.Detectors != nil {
 					var failurePercentage2 *shared.MeshCircuitBreakerItemSpecFailurePercentage
-					if toItem.Default.OutlierDetection.Detectors.FailurePercentage != nil {
+					if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage != nil {
 						minimumHosts4 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
-							*minimumHosts4 = int(toItem.Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.IsNull() {
+							*minimumHosts4 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts4 = nil
 						}
 						requestVolume4 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
-							*requestVolume4 = int(toItem.Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.IsNull() {
+							*requestVolume4 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.RequestVolume.ValueInt32())
 						} else {
 							requestVolume4 = nil
 						}
 						threshold2 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
-							*threshold2 = int(toItem.Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.IsNull() {
+							*threshold2 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.FailurePercentage.Threshold.ValueInt32())
 						} else {
 							threshold2 = nil
 						}
@@ -1134,10 +1134,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var gatewayFailures2 *shared.MeshCircuitBreakerItemSpecGatewayFailures
-					if toItem.Default.OutlierDetection.Detectors.GatewayFailures != nil {
+					if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.GatewayFailures != nil {
 						consecutive6 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
-							*consecutive6 = int(toItem.Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.IsNull() {
+							*consecutive6 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.GatewayFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive6 = nil
 						}
@@ -1146,10 +1146,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var localOriginFailures2 *shared.MeshCircuitBreakerItemSpecLocalOriginFailures
-					if toItem.Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
+					if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.LocalOriginFailures != nil {
 						consecutive7 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
-							*consecutive7 = int(toItem.Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.IsNull() {
+							*consecutive7 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.LocalOriginFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive7 = nil
 						}
@@ -1158,24 +1158,24 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var successRate2 *shared.MeshCircuitBreakerItemSpecSuccessRate
-					if toItem.Default.OutlierDetection.Detectors.SuccessRate != nil {
+					if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate != nil {
 						minimumHosts5 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
-							*minimumHosts5 = int(toItem.Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.IsNull() {
+							*minimumHosts5 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.MinimumHosts.ValueInt32())
 						} else {
 							minimumHosts5 = nil
 						}
 						requestVolume5 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
-							*requestVolume5 = int(toItem.Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.IsNull() {
+							*requestVolume5 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.RequestVolume.ValueInt32())
 						} else {
 							requestVolume5 = nil
 						}
 						var standardDeviationFactor2 *shared.MeshCircuitBreakerItemSpecStandardDeviationFactor
-						if toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
+						if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor != nil {
 							integer4 := new(int64)
-							if !toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
-								*integer4 = toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
+							if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.IsNull() {
+								*integer4 = r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Integer.ValueInt64()
 							} else {
 								integer4 = nil
 							}
@@ -1185,8 +1185,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 								}
 							}
 							str4 := new(string)
-							if !toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
-								*str4 = toItem.Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
+							if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.IsNull() {
+								*str4 = r.Spec.To[toIndex].Default.OutlierDetection.Detectors.SuccessRate.StandardDeviationFactor.Str.ValueString()
 							} else {
 								str4 = nil
 							}
@@ -1203,10 +1203,10 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					var totalFailures2 *shared.MeshCircuitBreakerItemSpecTotalFailures
-					if toItem.Default.OutlierDetection.Detectors.TotalFailures != nil {
+					if r.Spec.To[toIndex].Default.OutlierDetection.Detectors.TotalFailures != nil {
 						consecutive8 := new(int)
-						if !toItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !toItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
-							*consecutive8 = int(toItem.Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
+						if !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.IsNull() {
+							*consecutive8 = int(r.Spec.To[toIndex].Default.OutlierDetection.Detectors.TotalFailures.Consecutive.ValueInt32())
 						} else {
 							consecutive8 = nil
 						}
@@ -1223,16 +1223,16 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				disabled2 := new(bool)
-				if !toItem.Default.OutlierDetection.Disabled.IsUnknown() && !toItem.Default.OutlierDetection.Disabled.IsNull() {
-					*disabled2 = toItem.Default.OutlierDetection.Disabled.ValueBool()
+				if !r.Spec.To[toIndex].Default.OutlierDetection.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Disabled.IsNull() {
+					*disabled2 = r.Spec.To[toIndex].Default.OutlierDetection.Disabled.ValueBool()
 				} else {
 					disabled2 = nil
 				}
 				var healthyPanicThreshold2 *shared.MeshCircuitBreakerItemSpecHealthyPanicThreshold
-				if toItem.Default.OutlierDetection.HealthyPanicThreshold != nil {
+				if r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold != nil {
 					integer5 := new(int64)
-					if !toItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !toItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
-						*integer5 = toItem.Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
+					if !r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.IsNull() {
+						*integer5 = r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Integer.ValueInt64()
 					} else {
 						integer5 = nil
 					}
@@ -1242,8 +1242,8 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 						}
 					}
 					str5 := new(string)
-					if !toItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !toItem.Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
-						*str5 = toItem.Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
+					if !r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.IsNull() {
+						*str5 = r.Spec.To[toIndex].Default.OutlierDetection.HealthyPanicThreshold.Str.ValueString()
 					} else {
 						str5 = nil
 					}
@@ -1254,20 +1254,20 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 					}
 				}
 				interval2 := new(string)
-				if !toItem.Default.OutlierDetection.Interval.IsUnknown() && !toItem.Default.OutlierDetection.Interval.IsNull() {
-					*interval2 = toItem.Default.OutlierDetection.Interval.ValueString()
+				if !r.Spec.To[toIndex].Default.OutlierDetection.Interval.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.Interval.IsNull() {
+					*interval2 = r.Spec.To[toIndex].Default.OutlierDetection.Interval.ValueString()
 				} else {
 					interval2 = nil
 				}
 				maxEjectionPercent2 := new(int)
-				if !toItem.Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !toItem.Default.OutlierDetection.MaxEjectionPercent.IsNull() {
-					*maxEjectionPercent2 = int(toItem.Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
+				if !r.Spec.To[toIndex].Default.OutlierDetection.MaxEjectionPercent.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.MaxEjectionPercent.IsNull() {
+					*maxEjectionPercent2 = int(r.Spec.To[toIndex].Default.OutlierDetection.MaxEjectionPercent.ValueInt32())
 				} else {
 					maxEjectionPercent2 = nil
 				}
 				splitExternalAndLocalErrors2 := new(bool)
-				if !toItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !toItem.Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
-					*splitExternalAndLocalErrors2 = toItem.Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
+				if !r.Spec.To[toIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsUnknown() && !r.Spec.To[toIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.IsNull() {
+					*splitExternalAndLocalErrors2 = r.Spec.To[toIndex].Default.OutlierDetection.SplitExternalAndLocalErrors.ValueBool()
 				} else {
 					splitExternalAndLocalErrors2 = nil
 				}
@@ -1286,46 +1286,46 @@ func (r *MeshCircuitBreakerResourceModel) ToSharedMeshCircuitBreakerItemInput(ct
 				OutlierDetection: outlierDetection2,
 			}
 		}
-		kind2 := shared.MeshCircuitBreakerItemSpecToKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshCircuitBreakerItemSpecToKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name3 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name3 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshCircuitBreakerItemSpecToProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshCircuitBreakerItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshCircuitBreakerItemSpecToProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshcontrolplane_resource.go
+++ b/internal/provider/meshcontrolplane_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_boolvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/boolvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -67,9 +66,6 @@ func (r *MeshControlPlaneResource) Schema(ctx context.Context, req resource.Sche
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -186,9 +182,6 @@ func (r *MeshControlPlaneResource) Schema(ctx context.Context, req resource.Sche
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 		},
@@ -425,7 +418,10 @@ func (r *MeshControlPlaneResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshcontrolplane_resource_sdk.go
+++ b/internal/provider/meshcontrolplane_resource_sdk.go
@@ -113,21 +113,21 @@ func (r *MeshControlPlaneResourceModel) ToSharedCreateMeshControlPlaneRequest(ct
 		description = nil
 	}
 	features := make([]shared.MeshControlPlaneFeature, 0, len(r.Features))
-	for _, featuresItem := range r.Features {
-		typeVar := shared.MeshControlPlaneFeatureType(featuresItem.Type.ValueString())
+	for featuresIndex := range r.Features {
+		typeVar := shared.MeshControlPlaneFeatureType(r.Features[featuresIndex].Type.ValueString())
 		var hostnameGeneratorCreation *shared.MeshControlPlaneFeatureHostnameGenerationCreation
-		if featuresItem.HostnameGeneratorCreation != nil {
+		if r.Features[featuresIndex].HostnameGeneratorCreation != nil {
 			var enabled bool
-			enabled = featuresItem.HostnameGeneratorCreation.Enabled.ValueBool()
+			enabled = r.Features[featuresIndex].HostnameGeneratorCreation.Enabled.ValueBool()
 
 			hostnameGeneratorCreation = &shared.MeshControlPlaneFeatureHostnameGenerationCreation{
 				Enabled: enabled,
 			}
 		}
 		var meshCreation *shared.MeshControlPlaneFeatureMeshCreation
-		if featuresItem.MeshCreation != nil {
+		if r.Features[featuresIndex].MeshCreation != nil {
 			var enabled1 bool
-			enabled1 = featuresItem.MeshCreation.Enabled.ValueBool()
+			enabled1 = r.Features[featuresIndex].MeshCreation.Enabled.ValueBool()
 
 			meshCreation = &shared.MeshControlPlaneFeatureMeshCreation{
 				Enabled: enabled1,
@@ -142,10 +142,10 @@ func (r *MeshControlPlaneResourceModel) ToSharedCreateMeshControlPlaneRequest(ct
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -177,9 +177,9 @@ func (r *MeshControlPlaneResourceModel) ToSharedPutMeshControlPlaneRequest(ctx c
 	var labels map[string]string
 	if r.Labels != nil {
 		labels = make(map[string]string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Labels[labelsKey].ValueString()
 
 			labels[labelsKey] = labelsInst
 		}

--- a/internal/provider/meshexternalservice_resource.go
+++ b/internal/provider/meshexternalservice_resource.go
@@ -28,11 +28,9 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
-	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -85,9 +83,6 @@ func (r *MeshExternalServiceResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -112,9 +107,6 @@ func (r *MeshExternalServiceResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -446,9 +438,6 @@ func (r *MeshExternalServiceResource) Schema(ctx context.Context, req resource.S
 												Computed: true,
 												MarkdownDescription: `message is a human readable message indicating details about the transition.` + "\n" +
 													`This may be an empty string.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(32768),
-												},
 											},
 											"reason": schema.StringAttribute{
 												Computed: true,
@@ -457,32 +446,17 @@ func (r *MeshExternalServiceResource) Schema(ctx context.Context, req resource.S
 													`and whether the values are considered a guaranteed API.` + "\n" +
 													`The value should be a CamelCase string.` + "\n" +
 													`This field may not be empty.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthBetween(1, 1024),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`), "must match pattern "+regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`).String()),
-												},
 											},
 											"status": schema.StringAttribute{
 												Computed: true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
-												Description: `status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]`,
-												Validators: []validator.String{
-													stringvalidator.OneOf(
-														"True",
-														"False",
-														"Unknown",
-													),
-												},
+												Description: `status of the condition, one of True, False, Unknown.`,
 											},
 											"type": schema.StringAttribute{
 												Computed:    true,
 												Description: `type of condition in CamelCase or in foo.example.com/CamelCase.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(316),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`), "must match pattern "+regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`).String()),
-												},
 											},
 										},
 									},
@@ -844,7 +818,10 @@ func (r *MeshExternalServiceResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshexternalservice_resource_sdk.go
+++ b/internal/provider/meshexternalservice_resource_sdk.go
@@ -289,12 +289,12 @@ func (r *MeshExternalServiceResourceModel) ToSharedMeshExternalServiceItemInput(
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	endpoints := make([]shared.Endpoints, 0, len(r.Spec.Endpoints))
-	for _, endpointsItem := range r.Spec.Endpoints {
+	for endpointsIndex := range r.Spec.Endpoints {
 		var address string
-		address = endpointsItem.Address.ValueString()
+		address = r.Spec.Endpoints[endpointsIndex].Address.ValueString()
 
 		var port int
-		port = int(endpointsItem.Port.ValueInt32())
+		port = int(r.Spec.Endpoints[endpointsIndex].Port.ValueInt32())
 
 		endpoints = append(endpoints, shared.Endpoints{
 			Address: address,
@@ -442,15 +442,15 @@ func (r *MeshExternalServiceResourceModel) ToSharedMeshExternalServiceItemInput(
 				serverName = nil
 			}
 			subjectAltNames := make([]shared.SubjectAltNames, 0, len(r.Spec.TLS.Verification.SubjectAltNames))
-			for _, subjectAltNamesItem := range r.Spec.TLS.Verification.SubjectAltNames {
+			for subjectAltNamesIndex := range r.Spec.TLS.Verification.SubjectAltNames {
 				type1 := new(shared.MeshExternalServiceItemSpecTLSType)
-				if !subjectAltNamesItem.Type.IsUnknown() && !subjectAltNamesItem.Type.IsNull() {
-					*type1 = shared.MeshExternalServiceItemSpecTLSType(subjectAltNamesItem.Type.ValueString())
+				if !r.Spec.TLS.Verification.SubjectAltNames[subjectAltNamesIndex].Type.IsUnknown() && !r.Spec.TLS.Verification.SubjectAltNames[subjectAltNamesIndex].Type.IsNull() {
+					*type1 = shared.MeshExternalServiceItemSpecTLSType(r.Spec.TLS.Verification.SubjectAltNames[subjectAltNamesIndex].Type.ValueString())
 				} else {
 					type1 = nil
 				}
 				var value string
-				value = subjectAltNamesItem.Value.ValueString()
+				value = r.Spec.TLS.Verification.SubjectAltNames[subjectAltNamesIndex].Value.ValueString()
 
 				subjectAltNames = append(subjectAltNames, shared.SubjectAltNames{
 					Type:  type1,

--- a/internal/provider/meshfaultinjection_resource.go
+++ b/internal/provider/meshfaultinjection_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -78,9 +77,6 @@ func (r *MeshFaultInjectionResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -105,9 +101,6 @@ func (r *MeshFaultInjectionResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1187,7 +1180,10 @@ func (r *MeshFaultInjectionResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshfaultinjection_resource_sdk.go
+++ b/internal/provider/meshfaultinjection_resource_sdk.go
@@ -384,20 +384,20 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshFaultInjectionItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshFaultInjectionItemDefault
-		if fromItem.Default != nil {
-			http := make([]shared.HTTP, 0, len(fromItem.Default.HTTP))
-			for _, httpItem := range fromItem.Default.HTTP {
+		if r.Spec.From[fromIndex].Default != nil {
+			http := make([]shared.HTTP, 0, len(r.Spec.From[fromIndex].Default.HTTP))
+			for httpIndex := range r.Spec.From[fromIndex].Default.HTTP {
 				var abort *shared.Abort
-				if httpItem.Abort != nil {
+				if r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort != nil {
 					var httpStatus int
-					httpStatus = int(httpItem.Abort.HTTPStatus.ValueInt32())
+					httpStatus = int(r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.HTTPStatus.ValueInt32())
 
 					var percentage shared.Percentage
 					integer := new(int64)
-					if !httpItem.Abort.Percentage.Integer.IsUnknown() && !httpItem.Abort.Percentage.Integer.IsNull() {
-						*integer = httpItem.Abort.Percentage.Integer.ValueInt64()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Integer.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Integer.IsNull() {
+						*integer = r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Integer.ValueInt64()
 					} else {
 						integer = nil
 					}
@@ -407,8 +407,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str := new(string)
-					if !httpItem.Abort.Percentage.Str.IsUnknown() && !httpItem.Abort.Percentage.Str.IsNull() {
-						*str = httpItem.Abort.Percentage.Str.ValueString()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Str.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Str.IsNull() {
+						*str = r.Spec.From[fromIndex].Default.HTTP[httpIndex].Abort.Percentage.Str.ValueString()
 					} else {
 						str = nil
 					}
@@ -423,11 +423,11 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				var delay *shared.Delay
-				if httpItem.Delay != nil {
+				if r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay != nil {
 					var percentage1 shared.MeshFaultInjectionItemPercentage
 					integer1 := new(int64)
-					if !httpItem.Delay.Percentage.Integer.IsUnknown() && !httpItem.Delay.Percentage.Integer.IsNull() {
-						*integer1 = httpItem.Delay.Percentage.Integer.ValueInt64()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Integer.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Integer.IsNull() {
+						*integer1 = r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Integer.ValueInt64()
 					} else {
 						integer1 = nil
 					}
@@ -437,8 +437,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str1 := new(string)
-					if !httpItem.Delay.Percentage.Str.IsUnknown() && !httpItem.Delay.Percentage.Str.IsNull() {
-						*str1 = httpItem.Delay.Percentage.Str.ValueString()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Str.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Str.IsNull() {
+						*str1 = r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Percentage.Str.ValueString()
 					} else {
 						str1 = nil
 					}
@@ -448,7 +448,7 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					var value string
-					value = httpItem.Delay.Value.ValueString()
+					value = r.Spec.From[fromIndex].Default.HTTP[httpIndex].Delay.Value.ValueString()
 
 					delay = &shared.Delay{
 						Percentage: percentage1,
@@ -456,14 +456,14 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				var responseBandwidth *shared.ResponseBandwidth
-				if httpItem.ResponseBandwidth != nil {
+				if r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth != nil {
 					var limit string
-					limit = httpItem.ResponseBandwidth.Limit.ValueString()
+					limit = r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Limit.ValueString()
 
 					var percentage2 shared.MeshFaultInjectionItemSpecPercentage
 					integer2 := new(int64)
-					if !httpItem.ResponseBandwidth.Percentage.Integer.IsUnknown() && !httpItem.ResponseBandwidth.Percentage.Integer.IsNull() {
-						*integer2 = httpItem.ResponseBandwidth.Percentage.Integer.ValueInt64()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Integer.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Integer.IsNull() {
+						*integer2 = r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Integer.ValueInt64()
 					} else {
 						integer2 = nil
 					}
@@ -473,8 +473,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str2 := new(string)
-					if !httpItem.ResponseBandwidth.Percentage.Str.IsUnknown() && !httpItem.ResponseBandwidth.Percentage.Str.IsNull() {
-						*str2 = httpItem.ResponseBandwidth.Percentage.Str.ValueString()
+					if !r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Str.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Str.IsNull() {
+						*str2 = r.Spec.From[fromIndex].Default.HTTP[httpIndex].ResponseBandwidth.Percentage.Str.ValueString()
 					} else {
 						str2 = nil
 					}
@@ -498,46 +498,46 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 				HTTP: http,
 			}
 		}
-		kind := shared.MeshFaultInjectionItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshFaultInjectionItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshFaultInjectionItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshFaultInjectionItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshFaultInjectionItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -557,18 +557,18 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 		})
 	}
 	rules := make([]shared.MeshFaultInjectionItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
-		http1 := make([]shared.MeshFaultInjectionItemHTTP, 0, len(rulesItem.Default.HTTP))
-		for _, httpItem1 := range rulesItem.Default.HTTP {
+	for rulesIndex := range r.Spec.Rules {
+		http1 := make([]shared.MeshFaultInjectionItemHTTP, 0, len(r.Spec.Rules[rulesIndex].Default.HTTP))
+		for httpIndex1 := range r.Spec.Rules[rulesIndex].Default.HTTP {
 			var abort1 *shared.MeshFaultInjectionItemAbort
-			if httpItem1.Abort != nil {
+			if r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort != nil {
 				var httpStatus1 int
-				httpStatus1 = int(httpItem1.Abort.HTTPStatus.ValueInt32())
+				httpStatus1 = int(r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.HTTPStatus.ValueInt32())
 
 				var percentage3 shared.MeshFaultInjectionItemSpecRulesPercentage
 				integer3 := new(int64)
-				if !httpItem1.Abort.Percentage.Integer.IsUnknown() && !httpItem1.Abort.Percentage.Integer.IsNull() {
-					*integer3 = httpItem1.Abort.Percentage.Integer.ValueInt64()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Integer.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Integer.IsNull() {
+					*integer3 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Integer.ValueInt64()
 				} else {
 					integer3 = nil
 				}
@@ -578,8 +578,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				str3 := new(string)
-				if !httpItem1.Abort.Percentage.Str.IsUnknown() && !httpItem1.Abort.Percentage.Str.IsNull() {
-					*str3 = httpItem1.Abort.Percentage.Str.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Str.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Str.IsNull() {
+					*str3 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Abort.Percentage.Str.ValueString()
 				} else {
 					str3 = nil
 				}
@@ -594,11 +594,11 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 				}
 			}
 			var delay1 *shared.MeshFaultInjectionItemDelay
-			if httpItem1.Delay != nil {
+			if r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay != nil {
 				var percentage4 shared.MeshFaultInjectionItemSpecRulesDefaultPercentage
 				integer4 := new(int64)
-				if !httpItem1.Delay.Percentage.Integer.IsUnknown() && !httpItem1.Delay.Percentage.Integer.IsNull() {
-					*integer4 = httpItem1.Delay.Percentage.Integer.ValueInt64()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Integer.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Integer.IsNull() {
+					*integer4 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Integer.ValueInt64()
 				} else {
 					integer4 = nil
 				}
@@ -608,8 +608,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				str4 := new(string)
-				if !httpItem1.Delay.Percentage.Str.IsUnknown() && !httpItem1.Delay.Percentage.Str.IsNull() {
-					*str4 = httpItem1.Delay.Percentage.Str.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Str.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Str.IsNull() {
+					*str4 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Percentage.Str.ValueString()
 				} else {
 					str4 = nil
 				}
@@ -619,7 +619,7 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				var value1 string
-				value1 = httpItem1.Delay.Value.ValueString()
+				value1 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].Delay.Value.ValueString()
 
 				delay1 = &shared.MeshFaultInjectionItemDelay{
 					Percentage: percentage4,
@@ -627,14 +627,14 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 				}
 			}
 			var responseBandwidth1 *shared.MeshFaultInjectionItemResponseBandwidth
-			if httpItem1.ResponseBandwidth != nil {
+			if r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth != nil {
 				var limit1 string
-				limit1 = httpItem1.ResponseBandwidth.Limit.ValueString()
+				limit1 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Limit.ValueString()
 
 				var percentage5 shared.MeshFaultInjectionItemSpecRulesDefaultHTTPPercentage
 				integer5 := new(int64)
-				if !httpItem1.ResponseBandwidth.Percentage.Integer.IsUnknown() && !httpItem1.ResponseBandwidth.Percentage.Integer.IsNull() {
-					*integer5 = httpItem1.ResponseBandwidth.Percentage.Integer.ValueInt64()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Integer.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Integer.IsNull() {
+					*integer5 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Integer.ValueInt64()
 				} else {
 					integer5 = nil
 				}
@@ -644,8 +644,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				str5 := new(string)
-				if !httpItem1.ResponseBandwidth.Percentage.Str.IsUnknown() && !httpItem1.ResponseBandwidth.Percentage.Str.IsNull() {
-					*str5 = httpItem1.ResponseBandwidth.Percentage.Str.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Str.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Str.IsNull() {
+					*str5 = r.Spec.Rules[rulesIndex].Default.HTTP[httpIndex1].ResponseBandwidth.Percentage.Str.ValueString()
 				} else {
 					str5 = nil
 				}
@@ -668,13 +668,13 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 		default1 := shared.MeshFaultInjectionItemSpecDefault{
 			HTTP: http1,
 		}
-		matches := make([]shared.Matches, 0, len(rulesItem.Matches))
-		for _, matchesItem := range rulesItem.Matches {
+		matches := make([]shared.Matches, 0, len(r.Spec.Rules[rulesIndex].Matches))
+		for matchesIndex := range r.Spec.Rules[rulesIndex].Matches {
 			var spiffeID *shared.MeshFaultInjectionItemSpiffeID
-			if matchesItem.SpiffeID != nil {
-				typeVar1 := shared.MeshFaultInjectionItemSpecType(matchesItem.SpiffeID.Type.ValueString())
+			if r.Spec.Rules[rulesIndex].Matches[matchesIndex].SpiffeID != nil {
+				typeVar1 := shared.MeshFaultInjectionItemSpecType(r.Spec.Rules[rulesIndex].Matches[matchesIndex].SpiffeID.Type.ValueString())
 				var value2 string
-				value2 = matchesItem.SpiffeID.Value.ValueString()
+				value2 = r.Spec.Rules[rulesIndex].Matches[matchesIndex].SpiffeID.Value.ValueString()
 
 				spiffeID = &shared.MeshFaultInjectionItemSpiffeID{
 					Type:  typeVar1,
@@ -694,9 +694,9 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshFaultInjectionItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -729,9 +729,9 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -747,20 +747,20 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 		}
 	}
 	to := make([]shared.MeshFaultInjectionItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var default2 *shared.MeshFaultInjectionItemSpecToDefault
-		if toItem.Default != nil {
-			http2 := make([]shared.MeshFaultInjectionItemSpecHTTP, 0, len(toItem.Default.HTTP))
-			for _, httpItem2 := range toItem.Default.HTTP {
+		if r.Spec.To[toIndex].Default != nil {
+			http2 := make([]shared.MeshFaultInjectionItemSpecHTTP, 0, len(r.Spec.To[toIndex].Default.HTTP))
+			for httpIndex2 := range r.Spec.To[toIndex].Default.HTTP {
 				var abort2 *shared.MeshFaultInjectionItemSpecAbort
-				if httpItem2.Abort != nil {
+				if r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort != nil {
 					var httpStatus2 int
-					httpStatus2 = int(httpItem2.Abort.HTTPStatus.ValueInt32())
+					httpStatus2 = int(r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.HTTPStatus.ValueInt32())
 
 					var percentage6 shared.MeshFaultInjectionItemSpecToPercentage
 					integer6 := new(int64)
-					if !httpItem2.Abort.Percentage.Integer.IsUnknown() && !httpItem2.Abort.Percentage.Integer.IsNull() {
-						*integer6 = httpItem2.Abort.Percentage.Integer.ValueInt64()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Integer.IsNull() {
+						*integer6 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Integer.ValueInt64()
 					} else {
 						integer6 = nil
 					}
@@ -770,8 +770,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str6 := new(string)
-					if !httpItem2.Abort.Percentage.Str.IsUnknown() && !httpItem2.Abort.Percentage.Str.IsNull() {
-						*str6 = httpItem2.Abort.Percentage.Str.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Str.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Str.IsNull() {
+						*str6 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].Abort.Percentage.Str.ValueString()
 					} else {
 						str6 = nil
 					}
@@ -786,11 +786,11 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				var delay2 *shared.MeshFaultInjectionItemSpecDelay
-				if httpItem2.Delay != nil {
+				if r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay != nil {
 					var percentage7 shared.MeshFaultInjectionItemSpecToDefaultPercentage
 					integer7 := new(int64)
-					if !httpItem2.Delay.Percentage.Integer.IsUnknown() && !httpItem2.Delay.Percentage.Integer.IsNull() {
-						*integer7 = httpItem2.Delay.Percentage.Integer.ValueInt64()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Integer.IsNull() {
+						*integer7 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Integer.ValueInt64()
 					} else {
 						integer7 = nil
 					}
@@ -800,8 +800,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str7 := new(string)
-					if !httpItem2.Delay.Percentage.Str.IsUnknown() && !httpItem2.Delay.Percentage.Str.IsNull() {
-						*str7 = httpItem2.Delay.Percentage.Str.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Str.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Str.IsNull() {
+						*str7 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Percentage.Str.ValueString()
 					} else {
 						str7 = nil
 					}
@@ -811,7 +811,7 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					var value3 string
-					value3 = httpItem2.Delay.Value.ValueString()
+					value3 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].Delay.Value.ValueString()
 
 					delay2 = &shared.MeshFaultInjectionItemSpecDelay{
 						Percentage: percentage7,
@@ -819,14 +819,14 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 					}
 				}
 				var responseBandwidth2 *shared.MeshFaultInjectionItemSpecResponseBandwidth
-				if httpItem2.ResponseBandwidth != nil {
+				if r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth != nil {
 					var limit2 string
-					limit2 = httpItem2.ResponseBandwidth.Limit.ValueString()
+					limit2 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Limit.ValueString()
 
 					var percentage8 shared.MeshFaultInjectionItemSpecToDefaultHTTPPercentage
 					integer8 := new(int64)
-					if !httpItem2.ResponseBandwidth.Percentage.Integer.IsUnknown() && !httpItem2.ResponseBandwidth.Percentage.Integer.IsNull() {
-						*integer8 = httpItem2.ResponseBandwidth.Percentage.Integer.ValueInt64()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Integer.IsNull() {
+						*integer8 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Integer.ValueInt64()
 					} else {
 						integer8 = nil
 					}
@@ -836,8 +836,8 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 						}
 					}
 					str8 := new(string)
-					if !httpItem2.ResponseBandwidth.Percentage.Str.IsUnknown() && !httpItem2.ResponseBandwidth.Percentage.Str.IsNull() {
-						*str8 = httpItem2.ResponseBandwidth.Percentage.Str.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Str.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Str.IsNull() {
+						*str8 = r.Spec.To[toIndex].Default.HTTP[httpIndex2].ResponseBandwidth.Percentage.Str.ValueString()
 					} else {
 						str8 = nil
 					}
@@ -861,46 +861,46 @@ func (r *MeshFaultInjectionResourceModel) ToSharedMeshFaultInjectionItemInput(ct
 				HTTP: http2,
 			}
 		}
-		kind2 := shared.MeshFaultInjectionItemSpecToKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshFaultInjectionItemSpecToKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name3 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name3 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshFaultInjectionItemSpecToProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshFaultInjectionItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshFaultInjectionItemSpecToProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshgateway_resource.go
+++ b/internal/provider/meshgateway_resource.go
@@ -640,7 +640,10 @@ func (r *MeshGatewayResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshgateway_resource_sdk.go
+++ b/internal/provider/meshgateway_resource_sdk.go
@@ -219,30 +219,30 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 	var conf *shared.Conf
 	if r.Conf != nil {
 		listeners := make([]shared.Listeners, 0, len(r.Conf.Listeners))
-		for _, listenersItem := range r.Conf.Listeners {
+		for listenersIndex := range r.Conf.Listeners {
 			crossMesh := new(bool)
-			if !listenersItem.CrossMesh.IsUnknown() && !listenersItem.CrossMesh.IsNull() {
-				*crossMesh = listenersItem.CrossMesh.ValueBool()
+			if !r.Conf.Listeners[listenersIndex].CrossMesh.IsUnknown() && !r.Conf.Listeners[listenersIndex].CrossMesh.IsNull() {
+				*crossMesh = r.Conf.Listeners[listenersIndex].CrossMesh.ValueBool()
 			} else {
 				crossMesh = nil
 			}
 			hostname := new(string)
-			if !listenersItem.Hostname.IsUnknown() && !listenersItem.Hostname.IsNull() {
-				*hostname = listenersItem.Hostname.ValueString()
+			if !r.Conf.Listeners[listenersIndex].Hostname.IsUnknown() && !r.Conf.Listeners[listenersIndex].Hostname.IsNull() {
+				*hostname = r.Conf.Listeners[listenersIndex].Hostname.ValueString()
 			} else {
 				hostname = nil
 			}
 			port := new(int64)
-			if !listenersItem.Port.IsUnknown() && !listenersItem.Port.IsNull() {
-				*port = listenersItem.Port.ValueInt64()
+			if !r.Conf.Listeners[listenersIndex].Port.IsUnknown() && !r.Conf.Listeners[listenersIndex].Port.IsNull() {
+				*port = r.Conf.Listeners[listenersIndex].Port.ValueInt64()
 			} else {
 				port = nil
 			}
 			var protocol *shared.Protocol
-			if listenersItem.Protocol != nil {
+			if r.Conf.Listeners[listenersIndex].Protocol != nil {
 				str := new(string)
-				if !listenersItem.Protocol.Str.IsUnknown() && !listenersItem.Protocol.Str.IsNull() {
-					*str = listenersItem.Protocol.Str.ValueString()
+				if !r.Conf.Listeners[listenersIndex].Protocol.Str.IsUnknown() && !r.Conf.Listeners[listenersIndex].Protocol.Str.IsNull() {
+					*str = r.Conf.Listeners[listenersIndex].Protocol.Str.ValueString()
 				} else {
 					str = nil
 				}
@@ -252,8 +252,8 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 					}
 				}
 				integer := new(int64)
-				if !listenersItem.Protocol.Integer.IsUnknown() && !listenersItem.Protocol.Integer.IsNull() {
-					*integer = listenersItem.Protocol.Integer.ValueInt64()
+				if !r.Conf.Listeners[listenersIndex].Protocol.Integer.IsUnknown() && !r.Conf.Listeners[listenersIndex].Protocol.Integer.IsNull() {
+					*integer = r.Conf.Listeners[listenersIndex].Protocol.Integer.ValueInt64()
 				} else {
 					integer = nil
 				}
@@ -264,10 +264,10 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 				}
 			}
 			var resources *shared.Resources
-			if listenersItem.Resources != nil {
+			if r.Conf.Listeners[listenersIndex].Resources != nil {
 				connectionLimit := new(int64)
-				if !listenersItem.Resources.ConnectionLimit.IsUnknown() && !listenersItem.Resources.ConnectionLimit.IsNull() {
-					*connectionLimit = listenersItem.Resources.ConnectionLimit.ValueInt64()
+				if !r.Conf.Listeners[listenersIndex].Resources.ConnectionLimit.IsUnknown() && !r.Conf.Listeners[listenersIndex].Resources.ConnectionLimit.IsNull() {
+					*connectionLimit = r.Conf.Listeners[listenersIndex].Resources.ConnectionLimit.ValueInt64()
 				} else {
 					connectionLimit = nil
 				}
@@ -276,20 +276,20 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 				}
 			}
 			tags := make(map[string]string)
-			for tagsKey, tagsValue := range listenersItem.Tags {
+			for tagsKey := range r.Conf.Listeners[listenersIndex].Tags {
 				var tagsInst string
-				tagsInst = tagsValue.ValueString()
+				tagsInst = r.Conf.Listeners[listenersIndex].Tags[tagsKey].ValueString()
 
 				tags[tagsKey] = tagsInst
 			}
 			var tls *shared.MeshGatewayItemTLS
-			if listenersItem.TLS != nil {
-				certificates := make([]shared.Certificates, 0, len(listenersItem.TLS.Certificates))
-				for _, certificatesItem := range listenersItem.TLS.Certificates {
-					if certificatesItem.DataSourceFile != nil {
+			if r.Conf.Listeners[listenersIndex].TLS != nil {
+				certificates := make([]shared.Certificates, 0, len(r.Conf.Listeners[listenersIndex].TLS.Certificates))
+				for certificatesItem := range r.Conf.Listeners[listenersIndex].TLS.Certificates {
+					if r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceFile != nil {
 						file := new(string)
-						if !certificatesItem.DataSourceFile.File.IsUnknown() && !certificatesItem.DataSourceFile.File.IsNull() {
-							*file = certificatesItem.DataSourceFile.File.ValueString()
+						if !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceFile.File.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceFile.File.IsNull() {
+							*file = r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceFile.File.ValueString()
 						} else {
 							file = nil
 						}
@@ -300,10 +300,10 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 							DataSourceFile: &dataSourceFile,
 						})
 					}
-					if certificatesItem.DataSourceInline != nil {
+					if r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInline != nil {
 						inline := new(string)
-						if !certificatesItem.DataSourceInline.Inline.IsUnknown() && !certificatesItem.DataSourceInline.Inline.IsNull() {
-							*inline = certificatesItem.DataSourceInline.Inline.ValueString()
+						if !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInline.Inline.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInline.Inline.IsNull() {
+							*inline = r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInline.Inline.ValueString()
 						} else {
 							inline = nil
 						}
@@ -314,10 +314,10 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 							DataSourceInline: &dataSourceInline,
 						})
 					}
-					if certificatesItem.DataSourceInlineString != nil {
+					if r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInlineString != nil {
 						inlineString := new(string)
-						if !certificatesItem.DataSourceInlineString.InlineString.IsUnknown() && !certificatesItem.DataSourceInlineString.InlineString.IsNull() {
-							*inlineString = certificatesItem.DataSourceInlineString.InlineString.ValueString()
+						if !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInlineString.InlineString.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInlineString.InlineString.IsNull() {
+							*inlineString = r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceInlineString.InlineString.ValueString()
 						} else {
 							inlineString = nil
 						}
@@ -328,10 +328,10 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 							DataSourceInlineString: &dataSourceInlineString,
 						})
 					}
-					if certificatesItem.DataSourceSecret != nil {
+					if r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceSecret != nil {
 						secret := new(string)
-						if !certificatesItem.DataSourceSecret.Secret.IsUnknown() && !certificatesItem.DataSourceSecret.Secret.IsNull() {
-							*secret = certificatesItem.DataSourceSecret.Secret.ValueString()
+						if !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceSecret.Secret.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceSecret.Secret.IsNull() {
+							*secret = r.Conf.Listeners[listenersIndex].TLS.Certificates[certificatesItem].DataSourceSecret.Secret.ValueString()
 						} else {
 							secret = nil
 						}
@@ -344,10 +344,10 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 					}
 				}
 				var mode *shared.MeshGatewayItemMode
-				if listenersItem.TLS.Mode != nil {
+				if r.Conf.Listeners[listenersIndex].TLS.Mode != nil {
 					str1 := new(string)
-					if !listenersItem.TLS.Mode.Str.IsUnknown() && !listenersItem.TLS.Mode.Str.IsNull() {
-						*str1 = listenersItem.TLS.Mode.Str.ValueString()
+					if !r.Conf.Listeners[listenersIndex].TLS.Mode.Str.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Mode.Str.IsNull() {
+						*str1 = r.Conf.Listeners[listenersIndex].TLS.Mode.Str.ValueString()
 					} else {
 						str1 = nil
 					}
@@ -357,8 +357,8 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 						}
 					}
 					integer1 := new(int64)
-					if !listenersItem.TLS.Mode.Integer.IsUnknown() && !listenersItem.TLS.Mode.Integer.IsNull() {
-						*integer1 = listenersItem.TLS.Mode.Integer.ValueInt64()
+					if !r.Conf.Listeners[listenersIndex].TLS.Mode.Integer.IsUnknown() && !r.Conf.Listeners[listenersIndex].TLS.Mode.Integer.IsNull() {
+						*integer1 = r.Conf.Listeners[listenersIndex].TLS.Mode.Integer.ValueInt64()
 					} else {
 						integer1 = nil
 					}
@@ -369,7 +369,7 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 					}
 				}
 				var optionsVar *shared.OptionsObj
-				if listenersItem.TLS.Options != nil {
+				if r.Conf.Listeners[listenersIndex].TLS.Options != nil {
 					optionsVar = &shared.OptionsObj{}
 				}
 				tls = &shared.MeshGatewayItemTLS{
@@ -403,11 +403,11 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 	name = r.Name.ValueString()
 
 	selectors := make([]shared.Selectors, 0, len(r.Selectors))
-	for _, selectorsItem := range r.Selectors {
+	for selectorsIndex := range r.Selectors {
 		match := make(map[string]string)
-		for matchKey, matchValue := range selectorsItem.Match {
+		for matchKey := range r.Selectors[selectorsIndex].Match {
 			var matchInst string
-			matchInst = matchValue.ValueString()
+			matchInst = r.Selectors[selectorsIndex].Match[matchKey].ValueString()
 
 			match[matchKey] = matchInst
 		}
@@ -416,9 +416,9 @@ func (r *MeshGatewayResourceModel) ToSharedMeshGatewayItem(ctx context.Context) 
 		})
 	}
 	tags1 := make(map[string]string)
-	for tagsKey1, tagsValue1 := range r.Tags {
+	for tagsKey1 := range r.Tags {
 		var tagsInst1 string
-		tagsInst1 = tagsValue1.ValueString()
+		tagsInst1 = r.Tags[tagsKey1].ValueString()
 
 		tags1[tagsKey1] = tagsInst1
 	}

--- a/internal/provider/meshglobalratelimit_resource.go
+++ b/internal/provider/meshglobalratelimit_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_listvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
@@ -80,9 +79,6 @@ func (r *MeshGlobalRateLimitResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -107,9 +103,6 @@ func (r *MeshGlobalRateLimitResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1180,7 +1173,10 @@ func (r *MeshGlobalRateLimitResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshglobalratelimit_resource_sdk.go
+++ b/internal/provider/meshglobalratelimit_resource_sdk.go
@@ -375,24 +375,24 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshGlobalRateLimitItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshGlobalRateLimitItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			limitOnServiceFail := new(bool)
-			if !fromItem.Default.Backend.RateLimitService.LimitOnServiceFail.IsUnknown() && !fromItem.Default.Backend.RateLimitService.LimitOnServiceFail.IsNull() {
-				*limitOnServiceFail = fromItem.Default.Backend.RateLimitService.LimitOnServiceFail.ValueBool()
+			if !r.Spec.From[fromIndex].Default.Backend.RateLimitService.LimitOnServiceFail.IsUnknown() && !r.Spec.From[fromIndex].Default.Backend.RateLimitService.LimitOnServiceFail.IsNull() {
+				*limitOnServiceFail = r.Spec.From[fromIndex].Default.Backend.RateLimitService.LimitOnServiceFail.ValueBool()
 			} else {
 				limitOnServiceFail = nil
 			}
 			timeout := new(string)
-			if !fromItem.Default.Backend.RateLimitService.Timeout.IsUnknown() && !fromItem.Default.Backend.RateLimitService.Timeout.IsNull() {
-				*timeout = fromItem.Default.Backend.RateLimitService.Timeout.ValueString()
+			if !r.Spec.From[fromIndex].Default.Backend.RateLimitService.Timeout.IsUnknown() && !r.Spec.From[fromIndex].Default.Backend.RateLimitService.Timeout.IsNull() {
+				*timeout = r.Spec.From[fromIndex].Default.Backend.RateLimitService.Timeout.ValueString()
 			} else {
 				timeout = nil
 			}
 			url := new(string)
-			if !fromItem.Default.Backend.RateLimitService.URL.IsUnknown() && !fromItem.Default.Backend.RateLimitService.URL.IsNull() {
-				*url = fromItem.Default.Backend.RateLimitService.URL.ValueString()
+			if !r.Spec.From[fromIndex].Default.Backend.RateLimitService.URL.IsUnknown() && !r.Spec.From[fromIndex].Default.Backend.RateLimitService.URL.IsNull() {
+				*url = r.Spec.From[fromIndex].Default.Backend.RateLimitService.URL.ValueString()
 			} else {
 				url = nil
 			}
@@ -405,35 +405,35 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				RateLimitService: rateLimitService,
 			}
 			disabled := new(bool)
-			if !fromItem.Default.HTTP.Disabled.IsUnknown() && !fromItem.Default.HTTP.Disabled.IsNull() {
-				*disabled = fromItem.Default.HTTP.Disabled.ValueBool()
+			if !r.Spec.From[fromIndex].Default.HTTP.Disabled.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.Disabled.IsNull() {
+				*disabled = r.Spec.From[fromIndex].Default.HTTP.Disabled.ValueBool()
 			} else {
 				disabled = nil
 			}
 			var onRateLimit *shared.OnRateLimit
-			if fromItem.Default.HTTP.OnRateLimit != nil {
+			if r.Spec.From[fromIndex].Default.HTTP.OnRateLimit != nil {
 				var headers *shared.MeshGlobalRateLimitItemHeaders
-				if fromItem.Default.HTTP.OnRateLimit.Headers != nil {
-					add := make([]shared.MeshGlobalRateLimitItemAdd, 0, len(fromItem.Default.HTTP.OnRateLimit.Headers.Add))
-					for _, addItem := range fromItem.Default.HTTP.OnRateLimit.Headers.Add {
+				if r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers != nil {
+					add := make([]shared.MeshGlobalRateLimitItemAdd, 0, len(r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Add))
+					for addIndex := range r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Add {
 						var name1 string
-						name1 = addItem.Name.ValueString()
+						name1 = r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Add[addIndex].Name.ValueString()
 
 						var value string
-						value = addItem.Value.ValueString()
+						value = r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Add[addIndex].Value.ValueString()
 
 						add = append(add, shared.MeshGlobalRateLimitItemAdd{
 							Name:  name1,
 							Value: value,
 						})
 					}
-					set := make([]shared.MeshGlobalRateLimitItemSet, 0, len(fromItem.Default.HTTP.OnRateLimit.Headers.Set))
-					for _, setItem := range fromItem.Default.HTTP.OnRateLimit.Headers.Set {
+					set := make([]shared.MeshGlobalRateLimitItemSet, 0, len(r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Set))
+					for setIndex := range r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Set {
 						var name2 string
-						name2 = setItem.Name.ValueString()
+						name2 = r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Set[setIndex].Name.ValueString()
 
 						var value1 string
-						value1 = setItem.Value.ValueString()
+						value1 = r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Headers.Set[setIndex].Value.ValueString()
 
 						set = append(set, shared.MeshGlobalRateLimitItemSet{
 							Name:  name2,
@@ -446,8 +446,8 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					}
 				}
 				status := new(int)
-				if !fromItem.Default.HTTP.OnRateLimit.Status.IsUnknown() && !fromItem.Default.HTTP.OnRateLimit.Status.IsNull() {
-					*status = int(fromItem.Default.HTTP.OnRateLimit.Status.ValueInt32())
+				if !r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Status.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Status.IsNull() {
+					*status = int(r.Spec.From[fromIndex].Default.HTTP.OnRateLimit.Status.ValueInt32())
 				} else {
 					status = nil
 				}
@@ -456,18 +456,18 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					Status:  status,
 				}
 			}
-			ratelimitOnRequest := make([]shared.RatelimitOnRequest, 0, len(fromItem.Default.HTTP.RatelimitOnRequest))
-			for _, ratelimitOnRequestItem := range fromItem.Default.HTTP.RatelimitOnRequest {
-				kind := shared.MeshGlobalRateLimitItemSpecFromKind(ratelimitOnRequestItem.Kind.ValueString())
-				limits := make([]shared.Limits, 0, len(ratelimitOnRequestItem.Limits))
-				for _, limitsItem := range ratelimitOnRequestItem.Limits {
+			ratelimitOnRequest := make([]shared.RatelimitOnRequest, 0, len(r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest))
+			for ratelimitOnRequestIndex := range r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest {
+				kind := shared.MeshGlobalRateLimitItemSpecFromKind(r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Kind.ValueString())
+				limits := make([]shared.Limits, 0, len(r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits))
+				for limitsIndex := range r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits {
 					var requestRate *shared.MeshGlobalRateLimitItemSpecFromRequestRate
-					if limitsItem.RequestRate != nil {
+					if r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits[limitsIndex].RequestRate != nil {
 						var interval string
-						interval = limitsItem.RequestRate.Interval.ValueString()
+						interval = r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits[limitsIndex].RequestRate.Interval.ValueString()
 
 						var num int
-						num = int(limitsItem.RequestRate.Num.ValueInt32())
+						num = int(r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits[limitsIndex].RequestRate.Num.ValueInt32())
 
 						requestRate = &shared.MeshGlobalRateLimitItemSpecFromRequestRate{
 							Interval: interval,
@@ -475,7 +475,7 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 						}
 					}
 					var value2 string
-					value2 = limitsItem.Value.ValueString()
+					value2 = r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Limits[limitsIndex].Value.ValueString()
 
 					limits = append(limits, shared.Limits{
 						RequestRate: requestRate,
@@ -483,7 +483,7 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					})
 				}
 				var name3 string
-				name3 = ratelimitOnRequestItem.Name.ValueString()
+				name3 = r.Spec.From[fromIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex].Name.ValueString()
 
 				ratelimitOnRequest = append(ratelimitOnRequest, shared.RatelimitOnRequest{
 					Kind:   kind,
@@ -492,12 +492,12 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				})
 			}
 			var requestRate1 *shared.RequestRate
-			if fromItem.Default.HTTP.RequestRate != nil {
+			if r.Spec.From[fromIndex].Default.HTTP.RequestRate != nil {
 				var interval1 string
-				interval1 = fromItem.Default.HTTP.RequestRate.Interval.ValueString()
+				interval1 = r.Spec.From[fromIndex].Default.HTTP.RequestRate.Interval.ValueString()
 
 				var num1 int
-				num1 = int(fromItem.Default.HTTP.RequestRate.Num.ValueInt32())
+				num1 = int(r.Spec.From[fromIndex].Default.HTTP.RequestRate.Num.ValueInt32())
 
 				requestRate1 = &shared.RequestRate{
 					Interval: interval1,
@@ -511,8 +511,8 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				RequestRate:        requestRate1,
 			}
 			mode := new(shared.MeshGlobalRateLimitItemMode)
-			if !fromItem.Default.Mode.IsUnknown() && !fromItem.Default.Mode.IsNull() {
-				*mode = shared.MeshGlobalRateLimitItemMode(fromItem.Default.Mode.ValueString())
+			if !r.Spec.From[fromIndex].Default.Mode.IsUnknown() && !r.Spec.From[fromIndex].Default.Mode.IsNull() {
+				*mode = shared.MeshGlobalRateLimitItemMode(r.Spec.From[fromIndex].Default.Mode.ValueString())
 			} else {
 				mode = nil
 			}
@@ -522,46 +522,46 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				Mode:    mode,
 			}
 		}
-		kind1 := shared.MeshGlobalRateLimitItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind1 := shared.MeshGlobalRateLimitItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name4 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name4 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name4 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name4 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshGlobalRateLimitItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshGlobalRateLimitItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshGlobalRateLimitItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -584,9 +584,9 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 	if r.Spec.TargetRef != nil {
 		kind2 := shared.MeshGlobalRateLimitItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -619,9 +619,9 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -637,24 +637,24 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 		}
 	}
 	to := make([]shared.MeshGlobalRateLimitItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var default1 *shared.MeshGlobalRateLimitItemSpecDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			limitOnServiceFail1 := new(bool)
-			if !toItem.Default.Backend.RateLimitService.LimitOnServiceFail.IsUnknown() && !toItem.Default.Backend.RateLimitService.LimitOnServiceFail.IsNull() {
-				*limitOnServiceFail1 = toItem.Default.Backend.RateLimitService.LimitOnServiceFail.ValueBool()
+			if !r.Spec.To[toIndex].Default.Backend.RateLimitService.LimitOnServiceFail.IsUnknown() && !r.Spec.To[toIndex].Default.Backend.RateLimitService.LimitOnServiceFail.IsNull() {
+				*limitOnServiceFail1 = r.Spec.To[toIndex].Default.Backend.RateLimitService.LimitOnServiceFail.ValueBool()
 			} else {
 				limitOnServiceFail1 = nil
 			}
 			timeout1 := new(string)
-			if !toItem.Default.Backend.RateLimitService.Timeout.IsUnknown() && !toItem.Default.Backend.RateLimitService.Timeout.IsNull() {
-				*timeout1 = toItem.Default.Backend.RateLimitService.Timeout.ValueString()
+			if !r.Spec.To[toIndex].Default.Backend.RateLimitService.Timeout.IsUnknown() && !r.Spec.To[toIndex].Default.Backend.RateLimitService.Timeout.IsNull() {
+				*timeout1 = r.Spec.To[toIndex].Default.Backend.RateLimitService.Timeout.ValueString()
 			} else {
 				timeout1 = nil
 			}
 			url1 := new(string)
-			if !toItem.Default.Backend.RateLimitService.URL.IsUnknown() && !toItem.Default.Backend.RateLimitService.URL.IsNull() {
-				*url1 = toItem.Default.Backend.RateLimitService.URL.ValueString()
+			if !r.Spec.To[toIndex].Default.Backend.RateLimitService.URL.IsUnknown() && !r.Spec.To[toIndex].Default.Backend.RateLimitService.URL.IsNull() {
+				*url1 = r.Spec.To[toIndex].Default.Backend.RateLimitService.URL.ValueString()
 			} else {
 				url1 = nil
 			}
@@ -667,35 +667,35 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				RateLimitService: rateLimitService1,
 			}
 			disabled1 := new(bool)
-			if !toItem.Default.HTTP.Disabled.IsUnknown() && !toItem.Default.HTTP.Disabled.IsNull() {
-				*disabled1 = toItem.Default.HTTP.Disabled.ValueBool()
+			if !r.Spec.To[toIndex].Default.HTTP.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.Disabled.IsNull() {
+				*disabled1 = r.Spec.To[toIndex].Default.HTTP.Disabled.ValueBool()
 			} else {
 				disabled1 = nil
 			}
 			var onRateLimit1 *shared.MeshGlobalRateLimitItemOnRateLimit
-			if toItem.Default.HTTP.OnRateLimit != nil {
+			if r.Spec.To[toIndex].Default.HTTP.OnRateLimit != nil {
 				var headers1 *shared.MeshGlobalRateLimitItemSpecHeaders
-				if toItem.Default.HTTP.OnRateLimit.Headers != nil {
-					add1 := make([]shared.MeshGlobalRateLimitItemSpecAdd, 0, len(toItem.Default.HTTP.OnRateLimit.Headers.Add))
-					for _, addItem1 := range toItem.Default.HTTP.OnRateLimit.Headers.Add {
+				if r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers != nil {
+					add1 := make([]shared.MeshGlobalRateLimitItemSpecAdd, 0, len(r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Add))
+					for addIndex1 := range r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Add {
 						var name6 string
-						name6 = addItem1.Name.ValueString()
+						name6 = r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Add[addIndex1].Name.ValueString()
 
 						var value3 string
-						value3 = addItem1.Value.ValueString()
+						value3 = r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Add[addIndex1].Value.ValueString()
 
 						add1 = append(add1, shared.MeshGlobalRateLimitItemSpecAdd{
 							Name:  name6,
 							Value: value3,
 						})
 					}
-					set1 := make([]shared.MeshGlobalRateLimitItemSpecSet, 0, len(toItem.Default.HTTP.OnRateLimit.Headers.Set))
-					for _, setItem1 := range toItem.Default.HTTP.OnRateLimit.Headers.Set {
+					set1 := make([]shared.MeshGlobalRateLimitItemSpecSet, 0, len(r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Set))
+					for setIndex1 := range r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Set {
 						var name7 string
-						name7 = setItem1.Name.ValueString()
+						name7 = r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Set[setIndex1].Name.ValueString()
 
 						var value4 string
-						value4 = setItem1.Value.ValueString()
+						value4 = r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Headers.Set[setIndex1].Value.ValueString()
 
 						set1 = append(set1, shared.MeshGlobalRateLimitItemSpecSet{
 							Name:  name7,
@@ -708,8 +708,8 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					}
 				}
 				status1 := new(int)
-				if !toItem.Default.HTTP.OnRateLimit.Status.IsUnknown() && !toItem.Default.HTTP.OnRateLimit.Status.IsNull() {
-					*status1 = int(toItem.Default.HTTP.OnRateLimit.Status.ValueInt32())
+				if !r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Status.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Status.IsNull() {
+					*status1 = int(r.Spec.To[toIndex].Default.HTTP.OnRateLimit.Status.ValueInt32())
 				} else {
 					status1 = nil
 				}
@@ -718,18 +718,18 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					Status:  status1,
 				}
 			}
-			ratelimitOnRequest1 := make([]shared.MeshGlobalRateLimitItemRatelimitOnRequest, 0, len(toItem.Default.HTTP.RatelimitOnRequest))
-			for _, ratelimitOnRequestItem1 := range toItem.Default.HTTP.RatelimitOnRequest {
-				kind3 := shared.MeshGlobalRateLimitItemSpecToDefaultKind(ratelimitOnRequestItem1.Kind.ValueString())
-				limits1 := make([]shared.MeshGlobalRateLimitItemLimits, 0, len(ratelimitOnRequestItem1.Limits))
-				for _, limitsItem1 := range ratelimitOnRequestItem1.Limits {
+			ratelimitOnRequest1 := make([]shared.MeshGlobalRateLimitItemRatelimitOnRequest, 0, len(r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest))
+			for ratelimitOnRequestIndex1 := range r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest {
+				kind3 := shared.MeshGlobalRateLimitItemSpecToDefaultKind(r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Kind.ValueString())
+				limits1 := make([]shared.MeshGlobalRateLimitItemLimits, 0, len(r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits))
+				for limitsIndex1 := range r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits {
 					var requestRate2 *shared.MeshGlobalRateLimitItemSpecRequestRate
-					if limitsItem1.RequestRate != nil {
+					if r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits[limitsIndex1].RequestRate != nil {
 						var interval2 string
-						interval2 = limitsItem1.RequestRate.Interval.ValueString()
+						interval2 = r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits[limitsIndex1].RequestRate.Interval.ValueString()
 
 						var num2 int
-						num2 = int(limitsItem1.RequestRate.Num.ValueInt32())
+						num2 = int(r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits[limitsIndex1].RequestRate.Num.ValueInt32())
 
 						requestRate2 = &shared.MeshGlobalRateLimitItemSpecRequestRate{
 							Interval: interval2,
@@ -737,7 +737,7 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 						}
 					}
 					var value5 string
-					value5 = limitsItem1.Value.ValueString()
+					value5 = r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Limits[limitsIndex1].Value.ValueString()
 
 					limits1 = append(limits1, shared.MeshGlobalRateLimitItemLimits{
 						RequestRate: requestRate2,
@@ -745,7 +745,7 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 					})
 				}
 				var name8 string
-				name8 = ratelimitOnRequestItem1.Name.ValueString()
+				name8 = r.Spec.To[toIndex].Default.HTTP.RatelimitOnRequest[ratelimitOnRequestIndex1].Name.ValueString()
 
 				ratelimitOnRequest1 = append(ratelimitOnRequest1, shared.MeshGlobalRateLimitItemRatelimitOnRequest{
 					Kind:   kind3,
@@ -754,12 +754,12 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				})
 			}
 			var requestRate3 *shared.MeshGlobalRateLimitItemRequestRate
-			if toItem.Default.HTTP.RequestRate != nil {
+			if r.Spec.To[toIndex].Default.HTTP.RequestRate != nil {
 				var interval3 string
-				interval3 = toItem.Default.HTTP.RequestRate.Interval.ValueString()
+				interval3 = r.Spec.To[toIndex].Default.HTTP.RequestRate.Interval.ValueString()
 
 				var num3 int
-				num3 = int(toItem.Default.HTTP.RequestRate.Num.ValueInt32())
+				num3 = int(r.Spec.To[toIndex].Default.HTTP.RequestRate.Num.ValueInt32())
 
 				requestRate3 = &shared.MeshGlobalRateLimitItemRequestRate{
 					Interval: interval3,
@@ -773,8 +773,8 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				RequestRate:        requestRate3,
 			}
 			mode1 := new(shared.MeshGlobalRateLimitItemSpecMode)
-			if !toItem.Default.Mode.IsUnknown() && !toItem.Default.Mode.IsNull() {
-				*mode1 = shared.MeshGlobalRateLimitItemSpecMode(toItem.Default.Mode.ValueString())
+			if !r.Spec.To[toIndex].Default.Mode.IsUnknown() && !r.Spec.To[toIndex].Default.Mode.IsNull() {
+				*mode1 = shared.MeshGlobalRateLimitItemSpecMode(r.Spec.To[toIndex].Default.Mode.ValueString())
 			} else {
 				mode1 = nil
 			}
@@ -784,46 +784,46 @@ func (r *MeshGlobalRateLimitResourceModel) ToSharedMeshGlobalRateLimitItemInput(
 				Mode:    mode1,
 			}
 		}
-		kind4 := shared.MeshGlobalRateLimitItemSpecToKind(toItem.TargetRef.Kind.ValueString())
+		kind4 := shared.MeshGlobalRateLimitItemSpecToKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name9 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name9 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name9 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name9 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshGlobalRateLimitItemSpecToProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshGlobalRateLimitItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshGlobalRateLimitItemSpecToProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshhealthcheck_resource.go
+++ b/internal/provider/meshhealthcheck_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 	"regexp"
@@ -79,9 +78,6 @@ func (r *MeshHealthCheckResource) Schema(ctx context.Context, req resource.Schem
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshHealthCheckResource) Schema(ctx context.Context, req resource.Schem
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -857,7 +850,10 @@ func (r *MeshHealthCheckResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshhealthcheck_resource_sdk.go
+++ b/internal/provider/meshhealthcheck_resource_sdk.go
@@ -274,9 +274,9 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshHealthCheckItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -309,9 +309,9 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -327,44 +327,44 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 		}
 	}
 	to := make([]shared.MeshHealthCheckItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var defaultVar *shared.MeshHealthCheckItemDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			alwaysLogHealthCheckFailures := new(bool)
-			if !toItem.Default.AlwaysLogHealthCheckFailures.IsUnknown() && !toItem.Default.AlwaysLogHealthCheckFailures.IsNull() {
-				*alwaysLogHealthCheckFailures = toItem.Default.AlwaysLogHealthCheckFailures.ValueBool()
+			if !r.Spec.To[toIndex].Default.AlwaysLogHealthCheckFailures.IsUnknown() && !r.Spec.To[toIndex].Default.AlwaysLogHealthCheckFailures.IsNull() {
+				*alwaysLogHealthCheckFailures = r.Spec.To[toIndex].Default.AlwaysLogHealthCheckFailures.ValueBool()
 			} else {
 				alwaysLogHealthCheckFailures = nil
 			}
 			eventLogPath := new(string)
-			if !toItem.Default.EventLogPath.IsUnknown() && !toItem.Default.EventLogPath.IsNull() {
-				*eventLogPath = toItem.Default.EventLogPath.ValueString()
+			if !r.Spec.To[toIndex].Default.EventLogPath.IsUnknown() && !r.Spec.To[toIndex].Default.EventLogPath.IsNull() {
+				*eventLogPath = r.Spec.To[toIndex].Default.EventLogPath.ValueString()
 			} else {
 				eventLogPath = nil
 			}
 			failTrafficOnPanic := new(bool)
-			if !toItem.Default.FailTrafficOnPanic.IsUnknown() && !toItem.Default.FailTrafficOnPanic.IsNull() {
-				*failTrafficOnPanic = toItem.Default.FailTrafficOnPanic.ValueBool()
+			if !r.Spec.To[toIndex].Default.FailTrafficOnPanic.IsUnknown() && !r.Spec.To[toIndex].Default.FailTrafficOnPanic.IsNull() {
+				*failTrafficOnPanic = r.Spec.To[toIndex].Default.FailTrafficOnPanic.ValueBool()
 			} else {
 				failTrafficOnPanic = nil
 			}
 			var grpc *shared.Grpc
-			if toItem.Default.Grpc != nil {
+			if r.Spec.To[toIndex].Default.Grpc != nil {
 				authority := new(string)
-				if !toItem.Default.Grpc.Authority.IsUnknown() && !toItem.Default.Grpc.Authority.IsNull() {
-					*authority = toItem.Default.Grpc.Authority.ValueString()
+				if !r.Spec.To[toIndex].Default.Grpc.Authority.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.Authority.IsNull() {
+					*authority = r.Spec.To[toIndex].Default.Grpc.Authority.ValueString()
 				} else {
 					authority = nil
 				}
 				disabled := new(bool)
-				if !toItem.Default.Grpc.Disabled.IsUnknown() && !toItem.Default.Grpc.Disabled.IsNull() {
-					*disabled = toItem.Default.Grpc.Disabled.ValueBool()
+				if !r.Spec.To[toIndex].Default.Grpc.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.Disabled.IsNull() {
+					*disabled = r.Spec.To[toIndex].Default.Grpc.Disabled.ValueBool()
 				} else {
 					disabled = nil
 				}
 				serviceName := new(string)
-				if !toItem.Default.Grpc.ServiceName.IsUnknown() && !toItem.Default.Grpc.ServiceName.IsNull() {
-					*serviceName = toItem.Default.Grpc.ServiceName.ValueString()
+				if !r.Spec.To[toIndex].Default.Grpc.ServiceName.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.ServiceName.IsNull() {
+					*serviceName = r.Spec.To[toIndex].Default.Grpc.ServiceName.ValueString()
 				} else {
 					serviceName = nil
 				}
@@ -375,10 +375,10 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 				}
 			}
 			var healthyPanicThreshold *shared.HealthyPanicThreshold
-			if toItem.Default.HealthyPanicThreshold != nil {
+			if r.Spec.To[toIndex].Default.HealthyPanicThreshold != nil {
 				integer := new(int64)
-				if !toItem.Default.HealthyPanicThreshold.Integer.IsUnknown() && !toItem.Default.HealthyPanicThreshold.Integer.IsNull() {
-					*integer = toItem.Default.HealthyPanicThreshold.Integer.ValueInt64()
+				if !r.Spec.To[toIndex].Default.HealthyPanicThreshold.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.HealthyPanicThreshold.Integer.IsNull() {
+					*integer = r.Spec.To[toIndex].Default.HealthyPanicThreshold.Integer.ValueInt64()
 				} else {
 					integer = nil
 				}
@@ -388,8 +388,8 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 					}
 				}
 				str := new(string)
-				if !toItem.Default.HealthyPanicThreshold.Str.IsUnknown() && !toItem.Default.HealthyPanicThreshold.Str.IsNull() {
-					*str = toItem.Default.HealthyPanicThreshold.Str.ValueString()
+				if !r.Spec.To[toIndex].Default.HealthyPanicThreshold.Str.IsUnknown() && !r.Spec.To[toIndex].Default.HealthyPanicThreshold.Str.IsNull() {
+					*str = r.Spec.To[toIndex].Default.HealthyPanicThreshold.Str.ValueString()
 				} else {
 					str = nil
 				}
@@ -400,51 +400,51 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 				}
 			}
 			healthyThreshold := new(int)
-			if !toItem.Default.HealthyThreshold.IsUnknown() && !toItem.Default.HealthyThreshold.IsNull() {
-				*healthyThreshold = int(toItem.Default.HealthyThreshold.ValueInt32())
+			if !r.Spec.To[toIndex].Default.HealthyThreshold.IsUnknown() && !r.Spec.To[toIndex].Default.HealthyThreshold.IsNull() {
+				*healthyThreshold = int(r.Spec.To[toIndex].Default.HealthyThreshold.ValueInt32())
 			} else {
 				healthyThreshold = nil
 			}
 			var http *shared.MeshHealthCheckItemHTTP
-			if toItem.Default.HTTP != nil {
+			if r.Spec.To[toIndex].Default.HTTP != nil {
 				disabled1 := new(bool)
-				if !toItem.Default.HTTP.Disabled.IsUnknown() && !toItem.Default.HTTP.Disabled.IsNull() {
-					*disabled1 = toItem.Default.HTTP.Disabled.ValueBool()
+				if !r.Spec.To[toIndex].Default.HTTP.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.Disabled.IsNull() {
+					*disabled1 = r.Spec.To[toIndex].Default.HTTP.Disabled.ValueBool()
 				} else {
 					disabled1 = nil
 				}
-				expectedStatuses := make([]int64, 0, len(toItem.Default.HTTP.ExpectedStatuses))
-				for _, expectedStatusesItem := range toItem.Default.HTTP.ExpectedStatuses {
-					expectedStatuses = append(expectedStatuses, expectedStatusesItem.ValueInt64())
+				expectedStatuses := make([]int64, 0, len(r.Spec.To[toIndex].Default.HTTP.ExpectedStatuses))
+				for expectedStatusesIndex := range r.Spec.To[toIndex].Default.HTTP.ExpectedStatuses {
+					expectedStatuses = append(expectedStatuses, r.Spec.To[toIndex].Default.HTTP.ExpectedStatuses[expectedStatusesIndex].ValueInt64())
 				}
 				path := new(string)
-				if !toItem.Default.HTTP.Path.IsUnknown() && !toItem.Default.HTTP.Path.IsNull() {
-					*path = toItem.Default.HTTP.Path.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.Path.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.Path.IsNull() {
+					*path = r.Spec.To[toIndex].Default.HTTP.Path.ValueString()
 				} else {
 					path = nil
 				}
 				var requestHeadersToAdd *shared.RequestHeadersToAdd
-				if toItem.Default.HTTP.RequestHeadersToAdd != nil {
-					add := make([]shared.Add, 0, len(toItem.Default.HTTP.RequestHeadersToAdd.Add))
-					for _, addItem := range toItem.Default.HTTP.RequestHeadersToAdd.Add {
+				if r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd != nil {
+					add := make([]shared.Add, 0, len(r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Add))
+					for addIndex := range r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Add {
 						var name2 string
-						name2 = addItem.Name.ValueString()
+						name2 = r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Add[addIndex].Name.ValueString()
 
 						var value string
-						value = addItem.Value.ValueString()
+						value = r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Add[addIndex].Value.ValueString()
 
 						add = append(add, shared.Add{
 							Name:  name2,
 							Value: value,
 						})
 					}
-					set := make([]shared.Set, 0, len(toItem.Default.HTTP.RequestHeadersToAdd.Set))
-					for _, setItem := range toItem.Default.HTTP.RequestHeadersToAdd.Set {
+					set := make([]shared.Set, 0, len(r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Set))
+					for setIndex := range r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Set {
 						var name3 string
-						name3 = setItem.Name.ValueString()
+						name3 = r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Set[setIndex].Name.ValueString()
 
 						var value1 string
-						value1 = setItem.Value.ValueString()
+						value1 = r.Spec.To[toIndex].Default.HTTP.RequestHeadersToAdd.Set[setIndex].Value.ValueString()
 
 						set = append(set, shared.Set{
 							Name:  name3,
@@ -464,56 +464,56 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 				}
 			}
 			initialJitter := new(string)
-			if !toItem.Default.InitialJitter.IsUnknown() && !toItem.Default.InitialJitter.IsNull() {
-				*initialJitter = toItem.Default.InitialJitter.ValueString()
+			if !r.Spec.To[toIndex].Default.InitialJitter.IsUnknown() && !r.Spec.To[toIndex].Default.InitialJitter.IsNull() {
+				*initialJitter = r.Spec.To[toIndex].Default.InitialJitter.ValueString()
 			} else {
 				initialJitter = nil
 			}
 			interval := new(string)
-			if !toItem.Default.Interval.IsUnknown() && !toItem.Default.Interval.IsNull() {
-				*interval = toItem.Default.Interval.ValueString()
+			if !r.Spec.To[toIndex].Default.Interval.IsUnknown() && !r.Spec.To[toIndex].Default.Interval.IsNull() {
+				*interval = r.Spec.To[toIndex].Default.Interval.ValueString()
 			} else {
 				interval = nil
 			}
 			intervalJitter := new(string)
-			if !toItem.Default.IntervalJitter.IsUnknown() && !toItem.Default.IntervalJitter.IsNull() {
-				*intervalJitter = toItem.Default.IntervalJitter.ValueString()
+			if !r.Spec.To[toIndex].Default.IntervalJitter.IsUnknown() && !r.Spec.To[toIndex].Default.IntervalJitter.IsNull() {
+				*intervalJitter = r.Spec.To[toIndex].Default.IntervalJitter.ValueString()
 			} else {
 				intervalJitter = nil
 			}
 			intervalJitterPercent := new(int)
-			if !toItem.Default.IntervalJitterPercent.IsUnknown() && !toItem.Default.IntervalJitterPercent.IsNull() {
-				*intervalJitterPercent = int(toItem.Default.IntervalJitterPercent.ValueInt32())
+			if !r.Spec.To[toIndex].Default.IntervalJitterPercent.IsUnknown() && !r.Spec.To[toIndex].Default.IntervalJitterPercent.IsNull() {
+				*intervalJitterPercent = int(r.Spec.To[toIndex].Default.IntervalJitterPercent.ValueInt32())
 			} else {
 				intervalJitterPercent = nil
 			}
 			noTrafficInterval := new(string)
-			if !toItem.Default.NoTrafficInterval.IsUnknown() && !toItem.Default.NoTrafficInterval.IsNull() {
-				*noTrafficInterval = toItem.Default.NoTrafficInterval.ValueString()
+			if !r.Spec.To[toIndex].Default.NoTrafficInterval.IsUnknown() && !r.Spec.To[toIndex].Default.NoTrafficInterval.IsNull() {
+				*noTrafficInterval = r.Spec.To[toIndex].Default.NoTrafficInterval.ValueString()
 			} else {
 				noTrafficInterval = nil
 			}
 			reuseConnection := new(bool)
-			if !toItem.Default.ReuseConnection.IsUnknown() && !toItem.Default.ReuseConnection.IsNull() {
-				*reuseConnection = toItem.Default.ReuseConnection.ValueBool()
+			if !r.Spec.To[toIndex].Default.ReuseConnection.IsUnknown() && !r.Spec.To[toIndex].Default.ReuseConnection.IsNull() {
+				*reuseConnection = r.Spec.To[toIndex].Default.ReuseConnection.ValueBool()
 			} else {
 				reuseConnection = nil
 			}
 			var tcp *shared.TCP
-			if toItem.Default.TCP != nil {
+			if r.Spec.To[toIndex].Default.TCP != nil {
 				disabled2 := new(bool)
-				if !toItem.Default.TCP.Disabled.IsUnknown() && !toItem.Default.TCP.Disabled.IsNull() {
-					*disabled2 = toItem.Default.TCP.Disabled.ValueBool()
+				if !r.Spec.To[toIndex].Default.TCP.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.TCP.Disabled.IsNull() {
+					*disabled2 = r.Spec.To[toIndex].Default.TCP.Disabled.ValueBool()
 				} else {
 					disabled2 = nil
 				}
-				receive := make([]string, 0, len(toItem.Default.TCP.Receive))
-				for _, receiveItem := range toItem.Default.TCP.Receive {
-					receive = append(receive, receiveItem.ValueString())
+				receive := make([]string, 0, len(r.Spec.To[toIndex].Default.TCP.Receive))
+				for receiveIndex := range r.Spec.To[toIndex].Default.TCP.Receive {
+					receive = append(receive, r.Spec.To[toIndex].Default.TCP.Receive[receiveIndex].ValueString())
 				}
 				send := new(string)
-				if !toItem.Default.TCP.Send.IsUnknown() && !toItem.Default.TCP.Send.IsNull() {
-					*send = toItem.Default.TCP.Send.ValueString()
+				if !r.Spec.To[toIndex].Default.TCP.Send.IsUnknown() && !r.Spec.To[toIndex].Default.TCP.Send.IsNull() {
+					*send = r.Spec.To[toIndex].Default.TCP.Send.ValueString()
 				} else {
 					send = nil
 				}
@@ -524,14 +524,14 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 				}
 			}
 			timeout := new(string)
-			if !toItem.Default.Timeout.IsUnknown() && !toItem.Default.Timeout.IsNull() {
-				*timeout = toItem.Default.Timeout.ValueString()
+			if !r.Spec.To[toIndex].Default.Timeout.IsUnknown() && !r.Spec.To[toIndex].Default.Timeout.IsNull() {
+				*timeout = r.Spec.To[toIndex].Default.Timeout.ValueString()
 			} else {
 				timeout = nil
 			}
 			unhealthyThreshold := new(int)
-			if !toItem.Default.UnhealthyThreshold.IsUnknown() && !toItem.Default.UnhealthyThreshold.IsNull() {
-				*unhealthyThreshold = int(toItem.Default.UnhealthyThreshold.ValueInt32())
+			if !r.Spec.To[toIndex].Default.UnhealthyThreshold.IsUnknown() && !r.Spec.To[toIndex].Default.UnhealthyThreshold.IsNull() {
+				*unhealthyThreshold = int(r.Spec.To[toIndex].Default.UnhealthyThreshold.ValueInt32())
 			} else {
 				unhealthyThreshold = nil
 			}
@@ -554,46 +554,46 @@ func (r *MeshHealthCheckResourceModel) ToSharedMeshHealthCheckItemInput(ctx cont
 				UnhealthyThreshold:           unhealthyThreshold,
 			}
 		}
-		kind1 := shared.MeshHealthCheckItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind1 := shared.MeshHealthCheckItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range toItem.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
 		mesh2 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh2 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh2 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh2 = nil
 		}
 		name4 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name4 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name4 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name4 = nil
 		}
 		namespace1 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace1 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace1 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace1 = nil
 		}
-		proxyTypes1 := make([]shared.MeshHealthCheckItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem1 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes1 := make([]shared.MeshHealthCheckItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem1 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes1 = append(proxyTypes1, shared.MeshHealthCheckItemSpecProxyTypes(proxyTypesItem1.ValueString()))
 		}
 		sectionName1 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName1 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName1 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range toItem.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}

--- a/internal/provider/meshhostnamegenerator_resource.go
+++ b/internal/provider/meshhostnamegenerator_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -72,9 +71,6 @@ func (r *MeshHostnameGeneratorResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -91,9 +87,6 @@ func (r *MeshHostnameGeneratorResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -487,7 +480,10 @@ func (r *MeshHostnameGeneratorResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshhostnamegenerator_resource_sdk.go
+++ b/internal/provider/meshhostnamegenerator_resource_sdk.go
@@ -165,9 +165,9 @@ func (r *MeshHostnameGeneratorResourceModel) ToSharedHostnameGeneratorItemInput(
 	name = r.Name.ValueString()
 
 	labels := make(map[string]string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		var labelsInst string
-		labelsInst = labelsValue.ValueString()
+		labelsInst = r.Labels[labelsKey].ValueString()
 
 		labels[labelsKey] = labelsInst
 	}
@@ -190,9 +190,9 @@ func (r *MeshHostnameGeneratorResourceModel) ToSharedHostnameGeneratorItemInput(
 		var meshExternalService *shared.MeshExternalService
 		if r.Spec.Selector.MeshExternalService != nil {
 			matchLabels := make(map[string]string)
-			for matchLabelsKey, matchLabelsValue := range r.Spec.Selector.MeshExternalService.MatchLabels {
+			for matchLabelsKey := range r.Spec.Selector.MeshExternalService.MatchLabels {
 				var matchLabelsInst string
-				matchLabelsInst = matchLabelsValue.ValueString()
+				matchLabelsInst = r.Spec.Selector.MeshExternalService.MatchLabels[matchLabelsKey].ValueString()
 
 				matchLabels[matchLabelsKey] = matchLabelsInst
 			}
@@ -203,9 +203,9 @@ func (r *MeshHostnameGeneratorResourceModel) ToSharedHostnameGeneratorItemInput(
 		var meshMultiZoneService *shared.MeshMultiZoneService
 		if r.Spec.Selector.MeshMultiZoneService != nil {
 			matchLabels1 := make(map[string]string)
-			for matchLabelsKey1, matchLabelsValue1 := range r.Spec.Selector.MeshMultiZoneService.MatchLabels {
+			for matchLabelsKey1 := range r.Spec.Selector.MeshMultiZoneService.MatchLabels {
 				var matchLabelsInst1 string
-				matchLabelsInst1 = matchLabelsValue1.ValueString()
+				matchLabelsInst1 = r.Spec.Selector.MeshMultiZoneService.MatchLabels[matchLabelsKey1].ValueString()
 
 				matchLabels1[matchLabelsKey1] = matchLabelsInst1
 			}
@@ -216,9 +216,9 @@ func (r *MeshHostnameGeneratorResourceModel) ToSharedHostnameGeneratorItemInput(
 		var meshService *shared.MeshService
 		if r.Spec.Selector.MeshService != nil {
 			matchLabels2 := make(map[string]string)
-			for matchLabelsKey2, matchLabelsValue2 := range r.Spec.Selector.MeshService.MatchLabels {
+			for matchLabelsKey2 := range r.Spec.Selector.MeshService.MatchLabels {
 				var matchLabelsInst2 string
-				matchLabelsInst2 = matchLabelsValue2.ValueString()
+				matchLabelsInst2 = r.Spec.Selector.MeshService.MatchLabels[matchLabelsKey2].ValueString()
 
 				matchLabels2[matchLabelsKey2] = matchLabelsInst2
 			}

--- a/internal/provider/meshhttproute_resource.go
+++ b/internal/provider/meshhttproute_resource.go
@@ -27,7 +27,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_listvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -83,9 +82,6 @@ func (r *MeshHTTPRouteResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -110,9 +106,6 @@ func (r *MeshHTTPRouteResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1310,7 +1303,10 @@ func (r *MeshHTTPRouteResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshhttproute_resource_sdk.go
+++ b/internal/provider/meshhttproute_resource_sdk.go
@@ -426,9 +426,9 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshHTTPRouteItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -461,9 +461,9 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -479,67 +479,67 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 		}
 	}
 	to := make([]shared.MeshHTTPRouteItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
-		hostnames := make([]string, 0, len(toItem.Hostnames))
-		for _, hostnamesItem := range toItem.Hostnames {
-			hostnames = append(hostnames, hostnamesItem.ValueString())
+	for toIndex := range r.Spec.To {
+		hostnames := make([]string, 0, len(r.Spec.To[toIndex].Hostnames))
+		for hostnamesIndex := range r.Spec.To[toIndex].Hostnames {
+			hostnames = append(hostnames, r.Spec.To[toIndex].Hostnames[hostnamesIndex].ValueString())
 		}
-		rules := make([]shared.MeshHTTPRouteItemRules, 0, len(toItem.Rules))
-		for _, rulesItem := range toItem.Rules {
-			backendRefs := make([]shared.BackendRefs, 0, len(rulesItem.Default.BackendRefs))
-			for _, backendRefsItem := range rulesItem.Default.BackendRefs {
-				kind1 := shared.MeshHTTPRouteItemSpecToKind(backendRefsItem.Kind.ValueString())
+		rules := make([]shared.MeshHTTPRouteItemRules, 0, len(r.Spec.To[toIndex].Rules))
+		for rulesIndex := range r.Spec.To[toIndex].Rules {
+			backendRefs := make([]shared.BackendRefs, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs))
+			for backendRefsIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs {
+				kind1 := shared.MeshHTTPRouteItemSpecToKind(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Kind.ValueString())
 				labels2 := make(map[string]string)
-				for labelsKey1, labelsValue1 := range backendRefsItem.Labels {
+				for labelsKey1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Labels {
 					var labelsInst1 string
-					labelsInst1 = labelsValue1.ValueString()
+					labelsInst1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Labels[labelsKey1].ValueString()
 
 					labels2[labelsKey1] = labelsInst1
 				}
 				mesh2 := new(string)
-				if !backendRefsItem.Mesh.IsUnknown() && !backendRefsItem.Mesh.IsNull() {
-					*mesh2 = backendRefsItem.Mesh.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.IsNull() {
+					*mesh2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.ValueString()
 				} else {
 					mesh2 = nil
 				}
 				name2 := new(string)
-				if !backendRefsItem.Name.IsUnknown() && !backendRefsItem.Name.IsNull() {
-					*name2 = backendRefsItem.Name.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.IsNull() {
+					*name2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.ValueString()
 				} else {
 					name2 = nil
 				}
 				namespace1 := new(string)
-				if !backendRefsItem.Namespace.IsUnknown() && !backendRefsItem.Namespace.IsNull() {
-					*namespace1 = backendRefsItem.Namespace.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.IsNull() {
+					*namespace1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.ValueString()
 				} else {
 					namespace1 = nil
 				}
 				port := new(int)
-				if !backendRefsItem.Port.IsUnknown() && !backendRefsItem.Port.IsNull() {
-					*port = int(backendRefsItem.Port.ValueInt32())
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.IsNull() {
+					*port = int(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.ValueInt32())
 				} else {
 					port = nil
 				}
-				proxyTypes1 := make([]shared.MeshHTTPRouteItemSpecToProxyTypes, 0, len(backendRefsItem.ProxyTypes))
-				for _, proxyTypesItem1 := range backendRefsItem.ProxyTypes {
+				proxyTypes1 := make([]shared.MeshHTTPRouteItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].ProxyTypes))
+				for _, proxyTypesItem1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].ProxyTypes {
 					proxyTypes1 = append(proxyTypes1, shared.MeshHTTPRouteItemSpecToProxyTypes(proxyTypesItem1.ValueString()))
 				}
 				sectionName1 := new(string)
-				if !backendRefsItem.SectionName.IsUnknown() && !backendRefsItem.SectionName.IsNull() {
-					*sectionName1 = backendRefsItem.SectionName.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.IsNull() {
+					*sectionName1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.ValueString()
 				} else {
 					sectionName1 = nil
 				}
 				tags1 := make(map[string]string)
-				for tagsKey1, tagsValue1 := range backendRefsItem.Tags {
+				for tagsKey1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Tags {
 					var tagsInst1 string
-					tagsInst1 = tagsValue1.ValueString()
+					tagsInst1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Tags[tagsKey1].ValueString()
 
 					tags1[tagsKey1] = tagsInst1
 				}
 				weight := new(int64)
-				if !backendRefsItem.Weight.IsUnknown() && !backendRefsItem.Weight.IsNull() {
-					*weight = backendRefsItem.Weight.ValueInt64()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.IsNull() {
+					*weight = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.ValueInt64()
 				} else {
 					weight = nil
 				}
@@ -556,34 +556,34 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 					Weight:      weight,
 				})
 			}
-			filters := make([]shared.Filters, 0, len(rulesItem.Default.Filters))
-			for _, filtersItem := range rulesItem.Default.Filters {
+			filters := make([]shared.Filters, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters))
+			for filtersIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters {
 				var requestHeaderModifier *shared.RequestHeaderModifier
-				if filtersItem.RequestHeaderModifier != nil {
-					add := make([]shared.MeshHTTPRouteItemAdd, 0, len(filtersItem.RequestHeaderModifier.Add))
-					for _, addItem := range filtersItem.RequestHeaderModifier.Add {
+				if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier != nil {
+					add := make([]shared.MeshHTTPRouteItemAdd, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Add))
+					for addIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Add {
 						var name3 string
-						name3 = addItem.Name.ValueString()
+						name3 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Add[addIndex].Name.ValueString()
 
 						var value string
-						value = addItem.Value.ValueString()
+						value = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Add[addIndex].Value.ValueString()
 
 						add = append(add, shared.MeshHTTPRouteItemAdd{
 							Name:  name3,
 							Value: value,
 						})
 					}
-					remove := make([]string, 0, len(filtersItem.RequestHeaderModifier.Remove))
-					for _, removeItem := range filtersItem.RequestHeaderModifier.Remove {
-						remove = append(remove, removeItem.ValueString())
+					remove := make([]string, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Remove))
+					for removeIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Remove {
+						remove = append(remove, r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Remove[removeIndex].ValueString())
 					}
-					set := make([]shared.MeshHTTPRouteItemSet, 0, len(filtersItem.RequestHeaderModifier.Set))
-					for _, setItem := range filtersItem.RequestHeaderModifier.Set {
+					set := make([]shared.MeshHTTPRouteItemSet, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Set))
+					for setIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Set {
 						var name4 string
-						name4 = setItem.Name.ValueString()
+						name4 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Set[setIndex].Name.ValueString()
 
 						var value1 string
-						value1 = setItem.Value.ValueString()
+						value1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestHeaderModifier.Set[setIndex].Value.ValueString()
 
 						set = append(set, shared.MeshHTTPRouteItemSet{
 							Name:  name4,
@@ -597,59 +597,59 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 					}
 				}
 				var requestMirror *shared.RequestMirror
-				if filtersItem.RequestMirror != nil {
-					kind2 := shared.MeshHTTPRouteItemSpecToRulesKind(filtersItem.RequestMirror.BackendRef.Kind.ValueString())
+				if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror != nil {
+					kind2 := shared.MeshHTTPRouteItemSpecToRulesKind(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Kind.ValueString())
 					labels3 := make(map[string]string)
-					for labelsKey2, labelsValue2 := range filtersItem.RequestMirror.BackendRef.Labels {
+					for labelsKey2 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Labels {
 						var labelsInst2 string
-						labelsInst2 = labelsValue2.ValueString()
+						labelsInst2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Labels[labelsKey2].ValueString()
 
 						labels3[labelsKey2] = labelsInst2
 					}
 					mesh3 := new(string)
-					if !filtersItem.RequestMirror.BackendRef.Mesh.IsUnknown() && !filtersItem.RequestMirror.BackendRef.Mesh.IsNull() {
-						*mesh3 = filtersItem.RequestMirror.BackendRef.Mesh.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Mesh.IsNull() {
+						*mesh3 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Mesh.ValueString()
 					} else {
 						mesh3 = nil
 					}
 					name5 := new(string)
-					if !filtersItem.RequestMirror.BackendRef.Name.IsUnknown() && !filtersItem.RequestMirror.BackendRef.Name.IsNull() {
-						*name5 = filtersItem.RequestMirror.BackendRef.Name.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Name.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Name.IsNull() {
+						*name5 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Name.ValueString()
 					} else {
 						name5 = nil
 					}
 					namespace2 := new(string)
-					if !filtersItem.RequestMirror.BackendRef.Namespace.IsUnknown() && !filtersItem.RequestMirror.BackendRef.Namespace.IsNull() {
-						*namespace2 = filtersItem.RequestMirror.BackendRef.Namespace.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Namespace.IsNull() {
+						*namespace2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Namespace.ValueString()
 					} else {
 						namespace2 = nil
 					}
 					port1 := new(int)
-					if !filtersItem.RequestMirror.BackendRef.Port.IsUnknown() && !filtersItem.RequestMirror.BackendRef.Port.IsNull() {
-						*port1 = int(filtersItem.RequestMirror.BackendRef.Port.ValueInt32())
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Port.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Port.IsNull() {
+						*port1 = int(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Port.ValueInt32())
 					} else {
 						port1 = nil
 					}
-					proxyTypes2 := make([]shared.MeshHTTPRouteItemSpecToRulesProxyTypes, 0, len(filtersItem.RequestMirror.BackendRef.ProxyTypes))
-					for _, proxyTypesItem2 := range filtersItem.RequestMirror.BackendRef.ProxyTypes {
+					proxyTypes2 := make([]shared.MeshHTTPRouteItemSpecToRulesProxyTypes, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.ProxyTypes))
+					for _, proxyTypesItem2 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.ProxyTypes {
 						proxyTypes2 = append(proxyTypes2, shared.MeshHTTPRouteItemSpecToRulesProxyTypes(proxyTypesItem2.ValueString()))
 					}
 					sectionName2 := new(string)
-					if !filtersItem.RequestMirror.BackendRef.SectionName.IsUnknown() && !filtersItem.RequestMirror.BackendRef.SectionName.IsNull() {
-						*sectionName2 = filtersItem.RequestMirror.BackendRef.SectionName.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.SectionName.IsNull() {
+						*sectionName2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.SectionName.ValueString()
 					} else {
 						sectionName2 = nil
 					}
 					tags2 := make(map[string]string)
-					for tagsKey2, tagsValue2 := range filtersItem.RequestMirror.BackendRef.Tags {
+					for tagsKey2 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Tags {
 						var tagsInst2 string
-						tagsInst2 = tagsValue2.ValueString()
+						tagsInst2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Tags[tagsKey2].ValueString()
 
 						tags2[tagsKey2] = tagsInst2
 					}
 					weight1 := new(int64)
-					if !filtersItem.RequestMirror.BackendRef.Weight.IsUnknown() && !filtersItem.RequestMirror.BackendRef.Weight.IsNull() {
-						*weight1 = filtersItem.RequestMirror.BackendRef.Weight.ValueInt64()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Weight.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Weight.IsNull() {
+						*weight1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.BackendRef.Weight.ValueInt64()
 					} else {
 						weight1 = nil
 					}
@@ -666,10 +666,10 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 						Weight:      weight1,
 					}
 					var percentage *shared.MeshHTTPRouteItemPercentage
-					if filtersItem.RequestMirror.Percentage != nil {
+					if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage != nil {
 						integer := new(int64)
-						if !filtersItem.RequestMirror.Percentage.Integer.IsUnknown() && !filtersItem.RequestMirror.Percentage.Integer.IsNull() {
-							*integer = filtersItem.RequestMirror.Percentage.Integer.ValueInt64()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Integer.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Integer.IsNull() {
+							*integer = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Integer.ValueInt64()
 						} else {
 							integer = nil
 						}
@@ -679,8 +679,8 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 							}
 						}
 						str := new(string)
-						if !filtersItem.RequestMirror.Percentage.Str.IsUnknown() && !filtersItem.RequestMirror.Percentage.Str.IsNull() {
-							*str = filtersItem.RequestMirror.Percentage.Str.ValueString()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Str.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Str.IsNull() {
+							*str = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestMirror.Percentage.Str.ValueString()
 						} else {
 							str = nil
 						}
@@ -696,28 +696,28 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 					}
 				}
 				var requestRedirect *shared.RequestRedirect
-				if filtersItem.RequestRedirect != nil {
+				if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect != nil {
 					hostname := new(string)
-					if !filtersItem.RequestRedirect.Hostname.IsUnknown() && !filtersItem.RequestRedirect.Hostname.IsNull() {
-						*hostname = filtersItem.RequestRedirect.Hostname.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Hostname.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Hostname.IsNull() {
+						*hostname = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Hostname.ValueString()
 					} else {
 						hostname = nil
 					}
 					var path *shared.MeshHTTPRouteItemSpecPath
-					if filtersItem.RequestRedirect.Path != nil {
+					if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path != nil {
 						replaceFullPath := new(string)
-						if !filtersItem.RequestRedirect.Path.ReplaceFullPath.IsUnknown() && !filtersItem.RequestRedirect.Path.ReplaceFullPath.IsNull() {
-							*replaceFullPath = filtersItem.RequestRedirect.Path.ReplaceFullPath.ValueString()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplaceFullPath.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplaceFullPath.IsNull() {
+							*replaceFullPath = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplaceFullPath.ValueString()
 						} else {
 							replaceFullPath = nil
 						}
 						replacePrefixMatch := new(string)
-						if !filtersItem.RequestRedirect.Path.ReplacePrefixMatch.IsUnknown() && !filtersItem.RequestRedirect.Path.ReplacePrefixMatch.IsNull() {
-							*replacePrefixMatch = filtersItem.RequestRedirect.Path.ReplacePrefixMatch.ValueString()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplacePrefixMatch.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplacePrefixMatch.IsNull() {
+							*replacePrefixMatch = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.ReplacePrefixMatch.ValueString()
 						} else {
 							replacePrefixMatch = nil
 						}
-						typeVar1 := shared.MeshHTTPRouteItemSpecToRulesDefaultType(filtersItem.RequestRedirect.Path.Type.ValueString())
+						typeVar1 := shared.MeshHTTPRouteItemSpecToRulesDefaultType(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Path.Type.ValueString())
 						path = &shared.MeshHTTPRouteItemSpecPath{
 							ReplaceFullPath:    replaceFullPath,
 							ReplacePrefixMatch: replacePrefixMatch,
@@ -725,20 +725,20 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 						}
 					}
 					port2 := new(int)
-					if !filtersItem.RequestRedirect.Port.IsUnknown() && !filtersItem.RequestRedirect.Port.IsNull() {
-						*port2 = int(filtersItem.RequestRedirect.Port.ValueInt32())
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Port.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Port.IsNull() {
+						*port2 = int(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Port.ValueInt32())
 					} else {
 						port2 = nil
 					}
 					scheme := new(shared.Scheme)
-					if !filtersItem.RequestRedirect.Scheme.IsUnknown() && !filtersItem.RequestRedirect.Scheme.IsNull() {
-						*scheme = shared.Scheme(filtersItem.RequestRedirect.Scheme.ValueString())
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Scheme.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Scheme.IsNull() {
+						*scheme = shared.Scheme(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.Scheme.ValueString())
 					} else {
 						scheme = nil
 					}
 					statusCode := new(shared.StatusCode)
-					if !filtersItem.RequestRedirect.StatusCode.IsUnknown() && !filtersItem.RequestRedirect.StatusCode.IsNull() {
-						*statusCode = shared.StatusCode(filtersItem.RequestRedirect.StatusCode.ValueInt64())
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.StatusCode.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.StatusCode.IsNull() {
+						*statusCode = shared.StatusCode(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].RequestRedirect.StatusCode.ValueInt64())
 					} else {
 						statusCode = nil
 					}
@@ -751,31 +751,31 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 					}
 				}
 				var responseHeaderModifier *shared.ResponseHeaderModifier
-				if filtersItem.ResponseHeaderModifier != nil {
-					add1 := make([]shared.MeshHTTPRouteItemSpecAdd, 0, len(filtersItem.ResponseHeaderModifier.Add))
-					for _, addItem1 := range filtersItem.ResponseHeaderModifier.Add {
+				if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier != nil {
+					add1 := make([]shared.MeshHTTPRouteItemSpecAdd, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Add))
+					for addIndex1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Add {
 						var name6 string
-						name6 = addItem1.Name.ValueString()
+						name6 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Add[addIndex1].Name.ValueString()
 
 						var value2 string
-						value2 = addItem1.Value.ValueString()
+						value2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Add[addIndex1].Value.ValueString()
 
 						add1 = append(add1, shared.MeshHTTPRouteItemSpecAdd{
 							Name:  name6,
 							Value: value2,
 						})
 					}
-					remove1 := make([]string, 0, len(filtersItem.ResponseHeaderModifier.Remove))
-					for _, removeItem1 := range filtersItem.ResponseHeaderModifier.Remove {
-						remove1 = append(remove1, removeItem1.ValueString())
+					remove1 := make([]string, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Remove))
+					for removeIndex1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Remove {
+						remove1 = append(remove1, r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Remove[removeIndex1].ValueString())
 					}
-					set1 := make([]shared.MeshHTTPRouteItemSpecSet, 0, len(filtersItem.ResponseHeaderModifier.Set))
-					for _, setItem1 := range filtersItem.ResponseHeaderModifier.Set {
+					set1 := make([]shared.MeshHTTPRouteItemSpecSet, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Set))
+					for setIndex1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Set {
 						var name7 string
-						name7 = setItem1.Name.ValueString()
+						name7 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Set[setIndex1].Name.ValueString()
 
 						var value3 string
-						value3 = setItem1.Value.ValueString()
+						value3 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].ResponseHeaderModifier.Set[setIndex1].Value.ValueString()
 
 						set1 = append(set1, shared.MeshHTTPRouteItemSpecSet{
 							Name:  name7,
@@ -788,36 +788,36 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 						Set:    set1,
 					}
 				}
-				type1 := shared.MeshHTTPRouteItemSpecType(filtersItem.Type.ValueString())
+				type1 := shared.MeshHTTPRouteItemSpecType(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].Type.ValueString())
 				var urlRewrite *shared.URLRewrite
-				if filtersItem.URLRewrite != nil {
+				if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite != nil {
 					hostToBackendHostname := new(bool)
-					if !filtersItem.URLRewrite.HostToBackendHostname.IsUnknown() && !filtersItem.URLRewrite.HostToBackendHostname.IsNull() {
-						*hostToBackendHostname = filtersItem.URLRewrite.HostToBackendHostname.ValueBool()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.HostToBackendHostname.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.HostToBackendHostname.IsNull() {
+						*hostToBackendHostname = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.HostToBackendHostname.ValueBool()
 					} else {
 						hostToBackendHostname = nil
 					}
 					hostname1 := new(string)
-					if !filtersItem.URLRewrite.Hostname.IsUnknown() && !filtersItem.URLRewrite.Hostname.IsNull() {
-						*hostname1 = filtersItem.URLRewrite.Hostname.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Hostname.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Hostname.IsNull() {
+						*hostname1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Hostname.ValueString()
 					} else {
 						hostname1 = nil
 					}
 					var path1 *shared.MeshHTTPRouteItemPath
-					if filtersItem.URLRewrite.Path != nil {
+					if r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path != nil {
 						replaceFullPath1 := new(string)
-						if !filtersItem.URLRewrite.Path.ReplaceFullPath.IsUnknown() && !filtersItem.URLRewrite.Path.ReplaceFullPath.IsNull() {
-							*replaceFullPath1 = filtersItem.URLRewrite.Path.ReplaceFullPath.ValueString()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplaceFullPath.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplaceFullPath.IsNull() {
+							*replaceFullPath1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplaceFullPath.ValueString()
 						} else {
 							replaceFullPath1 = nil
 						}
 						replacePrefixMatch1 := new(string)
-						if !filtersItem.URLRewrite.Path.ReplacePrefixMatch.IsUnknown() && !filtersItem.URLRewrite.Path.ReplacePrefixMatch.IsNull() {
-							*replacePrefixMatch1 = filtersItem.URLRewrite.Path.ReplacePrefixMatch.ValueString()
+						if !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplacePrefixMatch.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplacePrefixMatch.IsNull() {
+							*replacePrefixMatch1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.ReplacePrefixMatch.ValueString()
 						} else {
 							replacePrefixMatch1 = nil
 						}
-						typeVar2 := shared.MeshHTTPRouteItemSpecToRulesDefaultFiltersType(filtersItem.URLRewrite.Path.Type.ValueString())
+						typeVar2 := shared.MeshHTTPRouteItemSpecToRulesDefaultFiltersType(r.Spec.To[toIndex].Rules[rulesIndex].Default.Filters[filtersIndex].URLRewrite.Path.Type.ValueString())
 						path1 = &shared.MeshHTTPRouteItemPath{
 							ReplaceFullPath:    replaceFullPath1,
 							ReplacePrefixMatch: replacePrefixMatch1,
@@ -843,22 +843,22 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 				BackendRefs: backendRefs,
 				Filters:     filters,
 			}
-			matches := make([]shared.MeshHTTPRouteItemMatches, 0, len(rulesItem.Matches))
-			for _, matchesItem := range rulesItem.Matches {
-				headers := make([]shared.Headers, 0, len(matchesItem.Headers))
-				for _, headersItem := range matchesItem.Headers {
+			matches := make([]shared.MeshHTTPRouteItemMatches, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Matches))
+			for matchesIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Matches {
+				headers := make([]shared.Headers, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers))
+				for headersIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers {
 					var name8 string
-					name8 = headersItem.Name.ValueString()
+					name8 = r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Name.ValueString()
 
 					type2 := new(shared.MeshHTTPRouteItemSpecToType)
-					if !headersItem.Type.IsUnknown() && !headersItem.Type.IsNull() {
-						*type2 = shared.MeshHTTPRouteItemSpecToType(headersItem.Type.ValueString())
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Type.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Type.IsNull() {
+						*type2 = shared.MeshHTTPRouteItemSpecToType(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Type.ValueString())
 					} else {
 						type2 = nil
 					}
 					value4 := new(string)
-					if !headersItem.Value.IsUnknown() && !headersItem.Value.IsNull() {
-						*value4 = headersItem.Value.ValueString()
+					if !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Value.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Value.IsNull() {
+						*value4 = r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Headers[headersIndex].Value.ValueString()
 					} else {
 						value4 = nil
 					}
@@ -869,30 +869,30 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 					})
 				}
 				method := new(shared.Method)
-				if !matchesItem.Method.IsUnknown() && !matchesItem.Method.IsNull() {
-					*method = shared.Method(matchesItem.Method.ValueString())
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Method.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Method.IsNull() {
+					*method = shared.Method(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Method.ValueString())
 				} else {
 					method = nil
 				}
 				var path2 *shared.Path
-				if matchesItem.Path != nil {
-					typeVar3 := shared.MeshHTTPRouteItemSpecToRulesType(matchesItem.Path.Type.ValueString())
+				if r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Path != nil {
+					typeVar3 := shared.MeshHTTPRouteItemSpecToRulesType(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Path.Type.ValueString())
 					var value5 string
-					value5 = matchesItem.Path.Value.ValueString()
+					value5 = r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].Path.Value.ValueString()
 
 					path2 = &shared.Path{
 						Type:  typeVar3,
 						Value: value5,
 					}
 				}
-				queryParams := make([]shared.QueryParams, 0, len(matchesItem.QueryParams))
-				for _, queryParamsItem := range matchesItem.QueryParams {
+				queryParams := make([]shared.QueryParams, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].QueryParams))
+				for queryParamsIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].QueryParams {
 					var name9 string
-					name9 = queryParamsItem.Name.ValueString()
+					name9 = r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].QueryParams[queryParamsIndex].Name.ValueString()
 
-					type3 := shared.MeshHTTPRouteItemSpecToRulesMatchesType(queryParamsItem.Type.ValueString())
+					type3 := shared.MeshHTTPRouteItemSpecToRulesMatchesType(r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].QueryParams[queryParamsIndex].Type.ValueString())
 					var value6 string
-					value6 = queryParamsItem.Value.ValueString()
+					value6 = r.Spec.To[toIndex].Rules[rulesIndex].Matches[matchesIndex].QueryParams[queryParamsIndex].Value.ValueString()
 
 					queryParams = append(queryParams, shared.QueryParams{
 						Name:  name9,
@@ -912,46 +912,46 @@ func (r *MeshHTTPRouteResourceModel) ToSharedMeshHTTPRouteItemInput(ctx context.
 				Matches: matches,
 			})
 		}
-		kind3 := shared.MeshHTTPRouteItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind3 := shared.MeshHTTPRouteItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels4 := make(map[string]string)
-		for labelsKey3, labelsValue3 := range toItem.TargetRef.Labels {
+		for labelsKey3 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst3 string
-			labelsInst3 = labelsValue3.ValueString()
+			labelsInst3 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey3].ValueString()
 
 			labels4[labelsKey3] = labelsInst3
 		}
 		mesh4 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh4 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh4 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh4 = nil
 		}
 		name10 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name10 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name10 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name10 = nil
 		}
 		namespace3 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace3 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace3 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace3 = nil
 		}
-		proxyTypes3 := make([]shared.MeshHTTPRouteItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem3 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes3 := make([]shared.MeshHTTPRouteItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem3 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes3 = append(proxyTypes3, shared.MeshHTTPRouteItemSpecProxyTypes(proxyTypesItem3.ValueString()))
 		}
 		sectionName3 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName3 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName3 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName3 = nil
 		}
 		tags3 := make(map[string]string)
-		for tagsKey3, tagsValue3 := range toItem.TargetRef.Tags {
+		for tagsKey3 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst3 string
-			tagsInst3 = tagsValue3.ValueString()
+			tagsInst3 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey3].ValueString()
 
 			tags3[tagsKey3] = tagsInst3
 		}

--- a/internal/provider/meshidentity_resource.go
+++ b/internal/provider/meshidentity_resource.go
@@ -23,8 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
-	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -77,9 +75,6 @@ func (r *MeshIdentityResource) Schema(ctx context.Context, req resource.SchemaRe
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +99,6 @@ func (r *MeshIdentityResource) Schema(ctx context.Context, req resource.SchemaRe
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -360,9 +352,6 @@ func (r *MeshIdentityResource) Schema(ctx context.Context, req resource.SchemaRe
 									Computed: true,
 									MarkdownDescription: `message is a human readable message indicating details about the transition.` + "\n" +
 										`This may be an empty string.`,
-									Validators: []validator.String{
-										stringvalidator.UTF8LengthAtMost(32768),
-									},
 								},
 								"reason": schema.StringAttribute{
 									Computed: true,
@@ -371,32 +360,17 @@ func (r *MeshIdentityResource) Schema(ctx context.Context, req resource.SchemaRe
 										`and whether the values are considered a guaranteed API.` + "\n" +
 										`The value should be a CamelCase string.` + "\n" +
 										`This field may not be empty.`,
-									Validators: []validator.String{
-										stringvalidator.UTF8LengthBetween(1, 1024),
-										stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`), "must match pattern "+regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`).String()),
-									},
 								},
 								"status": schema.StringAttribute{
 									Computed: true,
 									PlanModifiers: []planmodifier.String{
 										speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 									},
-									Description: `status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]`,
-									Validators: []validator.String{
-										stringvalidator.OneOf(
-											"True",
-											"False",
-											"Unknown",
-										),
-									},
+									Description: `status of the condition, one of True, False, Unknown.`,
 								},
 								"type": schema.StringAttribute{
 									Computed:    true,
 									Description: `type of condition in CamelCase or in foo.example.com/CamelCase.`,
-									Validators: []validator.String{
-										stringvalidator.UTF8LengthAtMost(316),
-										stringvalidator.RegexMatches(regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`), "must match pattern "+regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`).String()),
-									},
 								},
 							},
 						},
@@ -737,7 +711,10 @@ func (r *MeshIdentityResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshidentity_resource_sdk.go
+++ b/internal/provider/meshidentity_resource_sdk.go
@@ -456,9 +456,9 @@ func (r *MeshIdentityResourceModel) ToSharedMeshIdentityItemInput(ctx context.Co
 		var dataplane *shared.Dataplane
 		if r.Spec.Selector.Dataplane != nil {
 			matchLabels := make(map[string]string)
-			for matchLabelsKey, matchLabelsValue := range r.Spec.Selector.Dataplane.MatchLabels {
+			for matchLabelsKey := range r.Spec.Selector.Dataplane.MatchLabels {
 				var matchLabelsInst string
-				matchLabelsInst = matchLabelsValue.ValueString()
+				matchLabelsInst = r.Spec.Selector.Dataplane.MatchLabels[matchLabelsKey].ValueString()
 
 				matchLabels[matchLabelsKey] = matchLabelsInst
 			}

--- a/internal/provider/meshloadbalancingstrategy_resource.go
+++ b/internal/provider/meshloadbalancingstrategy_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_listvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -79,9 +78,6 @@ func (r *MeshLoadBalancingStrategyResource) Schema(ctx context.Context, req reso
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshLoadBalancingStrategyResource) Schema(ctx context.Context, req reso
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1242,7 +1235,10 @@ func (r *MeshLoadBalancingStrategyResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshloadbalancingstrategy_resource_sdk.go
+++ b/internal/provider/meshloadbalancingstrategy_resource_sdk.go
@@ -432,9 +432,9 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshLoadBalancingStrategyItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -467,9 +467,9 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -485,16 +485,16 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 		}
 	}
 	to := make([]shared.MeshLoadBalancingStrategyItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var defaultVar *shared.MeshLoadBalancingStrategyItemDefault
-		if toItem.Default != nil {
-			hashPolicies := make([]shared.HashPolicies, 0, len(toItem.Default.HashPolicies))
-			for _, hashPoliciesItem := range toItem.Default.HashPolicies {
+		if r.Spec.To[toIndex].Default != nil {
+			hashPolicies := make([]shared.HashPolicies, 0, len(r.Spec.To[toIndex].Default.HashPolicies))
+			for hashPoliciesIndex := range r.Spec.To[toIndex].Default.HashPolicies {
 				var connection *shared.Connection
-				if hashPoliciesItem.Connection != nil {
+				if r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Connection != nil {
 					sourceIP := new(bool)
-					if !hashPoliciesItem.Connection.SourceIP.IsUnknown() && !hashPoliciesItem.Connection.SourceIP.IsNull() {
-						*sourceIP = hashPoliciesItem.Connection.SourceIP.ValueBool()
+					if !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Connection.SourceIP.IsUnknown() && !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Connection.SourceIP.IsNull() {
+						*sourceIP = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Connection.SourceIP.ValueBool()
 					} else {
 						sourceIP = nil
 					}
@@ -503,19 +503,19 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				var cookie *shared.Cookie
-				if hashPoliciesItem.Cookie != nil {
+				if r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie != nil {
 					var name2 string
-					name2 = hashPoliciesItem.Cookie.Name.ValueString()
+					name2 = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.Name.ValueString()
 
 					path := new(string)
-					if !hashPoliciesItem.Cookie.Path.IsUnknown() && !hashPoliciesItem.Cookie.Path.IsNull() {
-						*path = hashPoliciesItem.Cookie.Path.ValueString()
+					if !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.Path.IsUnknown() && !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.Path.IsNull() {
+						*path = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.Path.ValueString()
 					} else {
 						path = nil
 					}
 					ttl := new(string)
-					if !hashPoliciesItem.Cookie.TTL.IsUnknown() && !hashPoliciesItem.Cookie.TTL.IsNull() {
-						*ttl = hashPoliciesItem.Cookie.TTL.ValueString()
+					if !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.TTL.IsUnknown() && !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.TTL.IsNull() {
+						*ttl = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Cookie.TTL.ValueString()
 					} else {
 						ttl = nil
 					}
@@ -526,39 +526,39 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				var filterState *shared.FilterState
-				if hashPoliciesItem.FilterState != nil {
+				if r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].FilterState != nil {
 					var key string
-					key = hashPoliciesItem.FilterState.Key.ValueString()
+					key = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].FilterState.Key.ValueString()
 
 					filterState = &shared.FilterState{
 						Key: key,
 					}
 				}
 				var header *shared.MeshLoadBalancingStrategyItemHeader
-				if hashPoliciesItem.Header != nil {
+				if r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Header != nil {
 					var name3 string
-					name3 = hashPoliciesItem.Header.Name.ValueString()
+					name3 = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Header.Name.ValueString()
 
 					header = &shared.MeshLoadBalancingStrategyItemHeader{
 						Name: name3,
 					}
 				}
 				var queryParameter *shared.QueryParameter
-				if hashPoliciesItem.QueryParameter != nil {
+				if r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].QueryParameter != nil {
 					var name4 string
-					name4 = hashPoliciesItem.QueryParameter.Name.ValueString()
+					name4 = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].QueryParameter.Name.ValueString()
 
 					queryParameter = &shared.QueryParameter{
 						Name: name4,
 					}
 				}
 				terminal := new(bool)
-				if !hashPoliciesItem.Terminal.IsUnknown() && !hashPoliciesItem.Terminal.IsNull() {
-					*terminal = hashPoliciesItem.Terminal.ValueBool()
+				if !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Terminal.IsUnknown() && !r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Terminal.IsNull() {
+					*terminal = r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Terminal.ValueBool()
 				} else {
 					terminal = nil
 				}
-				type1 := shared.MeshLoadBalancingStrategyItemSpecType(hashPoliciesItem.Type.ValueString())
+				type1 := shared.MeshLoadBalancingStrategyItemSpecType(r.Spec.To[toIndex].Default.HashPolicies[hashPoliciesIndex].Type.ValueString())
 				hashPolicies = append(hashPolicies, shared.HashPolicies{
 					Connection:     connection,
 					Cookie:         cookie,
@@ -570,14 +570,14 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 				})
 			}
 			var loadBalancer *shared.LoadBalancer
-			if toItem.Default.LoadBalancer != nil {
+			if r.Spec.To[toIndex].Default.LoadBalancer != nil {
 				var leastRequest *shared.LeastRequest
-				if toItem.Default.LoadBalancer.LeastRequest != nil {
+				if r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest != nil {
 					var activeRequestBias *shared.ActiveRequestBias
-					if toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias != nil {
+					if r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias != nil {
 						integer := new(int64)
-						if !toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.IsUnknown() && !toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.IsNull() {
-							*integer = toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.ValueInt64()
+						if !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.IsNull() {
+							*integer = r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Integer.ValueInt64()
 						} else {
 							integer = nil
 						}
@@ -587,8 +587,8 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						str := new(string)
-						if !toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.IsUnknown() && !toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.IsNull() {
-							*str = toItem.Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.ValueString()
+						if !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.IsNull() {
+							*str = r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ActiveRequestBias.Str.ValueString()
 						} else {
 							str = nil
 						}
@@ -599,8 +599,8 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 						}
 					}
 					choiceCount := new(int)
-					if !toItem.Default.LoadBalancer.LeastRequest.ChoiceCount.IsUnknown() && !toItem.Default.LoadBalancer.LeastRequest.ChoiceCount.IsNull() {
-						*choiceCount = int(toItem.Default.LoadBalancer.LeastRequest.ChoiceCount.ValueInt32())
+					if !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ChoiceCount.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ChoiceCount.IsNull() {
+						*choiceCount = int(r.Spec.To[toIndex].Default.LoadBalancer.LeastRequest.ChoiceCount.ValueInt32())
 					} else {
 						choiceCount = nil
 					}
@@ -610,14 +610,14 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				var maglev *shared.Maglev
-				if toItem.Default.LoadBalancer.Maglev != nil {
-					hashPolicies1 := make([]shared.MeshLoadBalancingStrategyItemHashPolicies, 0, len(toItem.Default.LoadBalancer.Maglev.HashPolicies))
-					for _, hashPoliciesItem1 := range toItem.Default.LoadBalancer.Maglev.HashPolicies {
+				if r.Spec.To[toIndex].Default.LoadBalancer.Maglev != nil {
+					hashPolicies1 := make([]shared.MeshLoadBalancingStrategyItemHashPolicies, 0, len(r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies))
+					for hashPoliciesIndex1 := range r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies {
 						var connection1 *shared.MeshLoadBalancingStrategyItemConnection
-						if hashPoliciesItem1.Connection != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Connection != nil {
 							sourceIp1 := new(bool)
-							if !hashPoliciesItem1.Connection.SourceIP.IsUnknown() && !hashPoliciesItem1.Connection.SourceIP.IsNull() {
-								*sourceIp1 = hashPoliciesItem1.Connection.SourceIP.ValueBool()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Connection.SourceIP.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Connection.SourceIP.IsNull() {
+								*sourceIp1 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Connection.SourceIP.ValueBool()
 							} else {
 								sourceIp1 = nil
 							}
@@ -626,19 +626,19 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						var cookie1 *shared.MeshLoadBalancingStrategyItemCookie
-						if hashPoliciesItem1.Cookie != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie != nil {
 							var name5 string
-							name5 = hashPoliciesItem1.Cookie.Name.ValueString()
+							name5 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.Name.ValueString()
 
 							path1 := new(string)
-							if !hashPoliciesItem1.Cookie.Path.IsUnknown() && !hashPoliciesItem1.Cookie.Path.IsNull() {
-								*path1 = hashPoliciesItem1.Cookie.Path.ValueString()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.Path.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.Path.IsNull() {
+								*path1 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.Path.ValueString()
 							} else {
 								path1 = nil
 							}
 							ttl1 := new(string)
-							if !hashPoliciesItem1.Cookie.TTL.IsUnknown() && !hashPoliciesItem1.Cookie.TTL.IsNull() {
-								*ttl1 = hashPoliciesItem1.Cookie.TTL.ValueString()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.TTL.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.TTL.IsNull() {
+								*ttl1 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Cookie.TTL.ValueString()
 							} else {
 								ttl1 = nil
 							}
@@ -649,39 +649,39 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						var filterState1 *shared.MeshLoadBalancingStrategyItemFilterState
-						if hashPoliciesItem1.FilterState != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].FilterState != nil {
 							var key1 string
-							key1 = hashPoliciesItem1.FilterState.Key.ValueString()
+							key1 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].FilterState.Key.ValueString()
 
 							filterState1 = &shared.MeshLoadBalancingStrategyItemFilterState{
 								Key: key1,
 							}
 						}
 						var header1 *shared.MeshLoadBalancingStrategyItemSpecToHeader
-						if hashPoliciesItem1.Header != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Header != nil {
 							var name6 string
-							name6 = hashPoliciesItem1.Header.Name.ValueString()
+							name6 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Header.Name.ValueString()
 
 							header1 = &shared.MeshLoadBalancingStrategyItemSpecToHeader{
 								Name: name6,
 							}
 						}
 						var queryParameter1 *shared.MeshLoadBalancingStrategyItemQueryParameter
-						if hashPoliciesItem1.QueryParameter != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].QueryParameter != nil {
 							var name7 string
-							name7 = hashPoliciesItem1.QueryParameter.Name.ValueString()
+							name7 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].QueryParameter.Name.ValueString()
 
 							queryParameter1 = &shared.MeshLoadBalancingStrategyItemQueryParameter{
 								Name: name7,
 							}
 						}
 						terminal1 := new(bool)
-						if !hashPoliciesItem1.Terminal.IsUnknown() && !hashPoliciesItem1.Terminal.IsNull() {
-							*terminal1 = hashPoliciesItem1.Terminal.ValueBool()
+						if !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Terminal.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Terminal.IsNull() {
+							*terminal1 = r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Terminal.ValueBool()
 						} else {
 							terminal1 = nil
 						}
-						type2 := shared.MeshLoadBalancingStrategyItemSpecToDefaultLoadBalancerType(hashPoliciesItem1.Type.ValueString())
+						type2 := shared.MeshLoadBalancingStrategyItemSpecToDefaultLoadBalancerType(r.Spec.To[toIndex].Default.LoadBalancer.Maglev.HashPolicies[hashPoliciesIndex1].Type.ValueString())
 						hashPolicies1 = append(hashPolicies1, shared.MeshLoadBalancingStrategyItemHashPolicies{
 							Connection:     connection1,
 							Cookie:         cookie1,
@@ -693,8 +693,8 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 						})
 					}
 					tableSize := new(int)
-					if !toItem.Default.LoadBalancer.Maglev.TableSize.IsUnknown() && !toItem.Default.LoadBalancer.Maglev.TableSize.IsNull() {
-						*tableSize = int(toItem.Default.LoadBalancer.Maglev.TableSize.ValueInt32())
+					if !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.TableSize.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.Maglev.TableSize.IsNull() {
+						*tableSize = int(r.Spec.To[toIndex].Default.LoadBalancer.Maglev.TableSize.ValueInt32())
 					} else {
 						tableSize = nil
 					}
@@ -704,24 +704,24 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				var random *shared.MeshLoadBalancingStrategyItemRandom
-				if toItem.Default.LoadBalancer.Random != nil {
+				if r.Spec.To[toIndex].Default.LoadBalancer.Random != nil {
 					random = &shared.MeshLoadBalancingStrategyItemRandom{}
 				}
 				var ringHash *shared.RingHash
-				if toItem.Default.LoadBalancer.RingHash != nil {
+				if r.Spec.To[toIndex].Default.LoadBalancer.RingHash != nil {
 					hashFunction := new(shared.HashFunction)
-					if !toItem.Default.LoadBalancer.RingHash.HashFunction.IsUnknown() && !toItem.Default.LoadBalancer.RingHash.HashFunction.IsNull() {
-						*hashFunction = shared.HashFunction(toItem.Default.LoadBalancer.RingHash.HashFunction.ValueString())
+					if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashFunction.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashFunction.IsNull() {
+						*hashFunction = shared.HashFunction(r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashFunction.ValueString())
 					} else {
 						hashFunction = nil
 					}
-					hashPolicies2 := make([]shared.MeshLoadBalancingStrategyItemSpecHashPolicies, 0, len(toItem.Default.LoadBalancer.RingHash.HashPolicies))
-					for _, hashPoliciesItem2 := range toItem.Default.LoadBalancer.RingHash.HashPolicies {
+					hashPolicies2 := make([]shared.MeshLoadBalancingStrategyItemSpecHashPolicies, 0, len(r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies))
+					for hashPoliciesIndex2 := range r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies {
 						var connection2 *shared.MeshLoadBalancingStrategyItemSpecConnection
-						if hashPoliciesItem2.Connection != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Connection != nil {
 							sourceIp2 := new(bool)
-							if !hashPoliciesItem2.Connection.SourceIP.IsUnknown() && !hashPoliciesItem2.Connection.SourceIP.IsNull() {
-								*sourceIp2 = hashPoliciesItem2.Connection.SourceIP.ValueBool()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Connection.SourceIP.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Connection.SourceIP.IsNull() {
+								*sourceIp2 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Connection.SourceIP.ValueBool()
 							} else {
 								sourceIp2 = nil
 							}
@@ -730,19 +730,19 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						var cookie2 *shared.MeshLoadBalancingStrategyItemSpecCookie
-						if hashPoliciesItem2.Cookie != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie != nil {
 							var name8 string
-							name8 = hashPoliciesItem2.Cookie.Name.ValueString()
+							name8 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.Name.ValueString()
 
 							path2 := new(string)
-							if !hashPoliciesItem2.Cookie.Path.IsUnknown() && !hashPoliciesItem2.Cookie.Path.IsNull() {
-								*path2 = hashPoliciesItem2.Cookie.Path.ValueString()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.Path.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.Path.IsNull() {
+								*path2 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.Path.ValueString()
 							} else {
 								path2 = nil
 							}
 							ttl2 := new(string)
-							if !hashPoliciesItem2.Cookie.TTL.IsUnknown() && !hashPoliciesItem2.Cookie.TTL.IsNull() {
-								*ttl2 = hashPoliciesItem2.Cookie.TTL.ValueString()
+							if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.TTL.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.TTL.IsNull() {
+								*ttl2 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Cookie.TTL.ValueString()
 							} else {
 								ttl2 = nil
 							}
@@ -753,39 +753,39 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						var filterState2 *shared.MeshLoadBalancingStrategyItemSpecFilterState
-						if hashPoliciesItem2.FilterState != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].FilterState != nil {
 							var key2 string
-							key2 = hashPoliciesItem2.FilterState.Key.ValueString()
+							key2 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].FilterState.Key.ValueString()
 
 							filterState2 = &shared.MeshLoadBalancingStrategyItemSpecFilterState{
 								Key: key2,
 							}
 						}
 						var header2 *shared.MeshLoadBalancingStrategyItemSpecHeader
-						if hashPoliciesItem2.Header != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Header != nil {
 							var name9 string
-							name9 = hashPoliciesItem2.Header.Name.ValueString()
+							name9 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Header.Name.ValueString()
 
 							header2 = &shared.MeshLoadBalancingStrategyItemSpecHeader{
 								Name: name9,
 							}
 						}
 						var queryParameter2 *shared.MeshLoadBalancingStrategyItemSpecQueryParameter
-						if hashPoliciesItem2.QueryParameter != nil {
+						if r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].QueryParameter != nil {
 							var name10 string
-							name10 = hashPoliciesItem2.QueryParameter.Name.ValueString()
+							name10 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].QueryParameter.Name.ValueString()
 
 							queryParameter2 = &shared.MeshLoadBalancingStrategyItemSpecQueryParameter{
 								Name: name10,
 							}
 						}
 						terminal2 := new(bool)
-						if !hashPoliciesItem2.Terminal.IsUnknown() && !hashPoliciesItem2.Terminal.IsNull() {
-							*terminal2 = hashPoliciesItem2.Terminal.ValueBool()
+						if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Terminal.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Terminal.IsNull() {
+							*terminal2 = r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Terminal.ValueBool()
 						} else {
 							terminal2 = nil
 						}
-						type3 := shared.MeshLoadBalancingStrategyItemSpecToDefaultType(hashPoliciesItem2.Type.ValueString())
+						type3 := shared.MeshLoadBalancingStrategyItemSpecToDefaultType(r.Spec.To[toIndex].Default.LoadBalancer.RingHash.HashPolicies[hashPoliciesIndex2].Type.ValueString())
 						hashPolicies2 = append(hashPolicies2, shared.MeshLoadBalancingStrategyItemSpecHashPolicies{
 							Connection:     connection2,
 							Cookie:         cookie2,
@@ -797,14 +797,14 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 						})
 					}
 					maxRingSize := new(int)
-					if !toItem.Default.LoadBalancer.RingHash.MaxRingSize.IsUnknown() && !toItem.Default.LoadBalancer.RingHash.MaxRingSize.IsNull() {
-						*maxRingSize = int(toItem.Default.LoadBalancer.RingHash.MaxRingSize.ValueInt32())
+					if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MaxRingSize.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MaxRingSize.IsNull() {
+						*maxRingSize = int(r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MaxRingSize.ValueInt32())
 					} else {
 						maxRingSize = nil
 					}
 					minRingSize := new(int)
-					if !toItem.Default.LoadBalancer.RingHash.MinRingSize.IsUnknown() && !toItem.Default.LoadBalancer.RingHash.MinRingSize.IsNull() {
-						*minRingSize = int(toItem.Default.LoadBalancer.RingHash.MinRingSize.ValueInt32())
+					if !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MinRingSize.IsUnknown() && !r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MinRingSize.IsNull() {
+						*minRingSize = int(r.Spec.To[toIndex].Default.LoadBalancer.RingHash.MinRingSize.ValueInt32())
 					} else {
 						minRingSize = nil
 					}
@@ -816,10 +816,10 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				var roundRobin *shared.RoundRobin
-				if toItem.Default.LoadBalancer.RoundRobin != nil {
+				if r.Spec.To[toIndex].Default.LoadBalancer.RoundRobin != nil {
 					roundRobin = &shared.RoundRobin{}
 				}
-				typeVar1 := shared.MeshLoadBalancingStrategyItemSpecToType(toItem.Default.LoadBalancer.Type.ValueString())
+				typeVar1 := shared.MeshLoadBalancingStrategyItemSpecToType(r.Spec.To[toIndex].Default.LoadBalancer.Type.ValueString())
 				loadBalancer = &shared.LoadBalancer{
 					LeastRequest: leastRequest,
 					Maglev:       maglev,
@@ -830,25 +830,25 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 				}
 			}
 			var localityAwareness *shared.LocalityAwareness
-			if toItem.Default.LocalityAwareness != nil {
+			if r.Spec.To[toIndex].Default.LocalityAwareness != nil {
 				var crossZone *shared.CrossZone
-				if toItem.Default.LocalityAwareness.CrossZone != nil {
-					failover := make([]shared.Failover, 0, len(toItem.Default.LocalityAwareness.CrossZone.Failover))
-					for _, failoverItem := range toItem.Default.LocalityAwareness.CrossZone.Failover {
+				if r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone != nil {
+					failover := make([]shared.Failover, 0, len(r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover))
+					for failoverIndex := range r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover {
 						var from *shared.MeshLoadBalancingStrategyItemFrom
-						if failoverItem.From != nil {
-							zones := make([]string, 0, len(failoverItem.From.Zones))
-							for _, zonesItem := range failoverItem.From.Zones {
-								zones = append(zones, zonesItem.ValueString())
+						if r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].From != nil {
+							zones := make([]string, 0, len(r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].From.Zones))
+							for zonesIndex := range r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].From.Zones {
+								zones = append(zones, r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].From.Zones[zonesIndex].ValueString())
 							}
 							from = &shared.MeshLoadBalancingStrategyItemFrom{
 								Zones: zones,
 							}
 						}
-						typeVar2 := shared.MeshLoadBalancingStrategyItemSpecToDefaultLocalityAwarenessType(failoverItem.To.Type.ValueString())
-						zones1 := make([]string, 0, len(failoverItem.To.Zones))
-						for _, zonesItem1 := range failoverItem.To.Zones {
-							zones1 = append(zones1, zonesItem1.ValueString())
+						typeVar2 := shared.MeshLoadBalancingStrategyItemSpecToDefaultLocalityAwarenessType(r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].To.Type.ValueString())
+						zones1 := make([]string, 0, len(r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].To.Zones))
+						for zonesIndex1 := range r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].To.Zones {
+							zones1 = append(zones1, r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.Failover[failoverIndex].To.Zones[zonesIndex1].ValueString())
 						}
 						to1 := shared.MeshLoadBalancingStrategyItemSpecTo{
 							Type:  typeVar2,
@@ -860,11 +860,11 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 						})
 					}
 					var failoverThreshold *shared.FailoverThreshold
-					if toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold != nil {
+					if r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold != nil {
 						var percentage shared.MeshLoadBalancingStrategyItemPercentage
 						integer1 := new(int64)
-						if !toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.IsUnknown() && !toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.IsNull() {
-							*integer1 = toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.ValueInt64()
+						if !r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.IsUnknown() && !r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.IsNull() {
+							*integer1 = r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Integer.ValueInt64()
 						} else {
 							integer1 = nil
 						}
@@ -874,8 +874,8 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 							}
 						}
 						str1 := new(string)
-						if !toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.IsUnknown() && !toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.IsNull() {
-							*str1 = toItem.Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.ValueString()
+						if !r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.IsUnknown() && !r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.IsNull() {
+							*str1 = r.Spec.To[toIndex].Default.LocalityAwareness.CrossZone.FailoverThreshold.Percentage.Str.ValueString()
 						} else {
 							str1 = nil
 						}
@@ -894,21 +894,21 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 					}
 				}
 				disabled := new(bool)
-				if !toItem.Default.LocalityAwareness.Disabled.IsUnknown() && !toItem.Default.LocalityAwareness.Disabled.IsNull() {
-					*disabled = toItem.Default.LocalityAwareness.Disabled.ValueBool()
+				if !r.Spec.To[toIndex].Default.LocalityAwareness.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.LocalityAwareness.Disabled.IsNull() {
+					*disabled = r.Spec.To[toIndex].Default.LocalityAwareness.Disabled.ValueBool()
 				} else {
 					disabled = nil
 				}
 				var localZone *shared.LocalZone
-				if toItem.Default.LocalityAwareness.LocalZone != nil {
-					affinityTags := make([]shared.AffinityTags, 0, len(toItem.Default.LocalityAwareness.LocalZone.AffinityTags))
-					for _, affinityTagsItem := range toItem.Default.LocalityAwareness.LocalZone.AffinityTags {
+				if r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone != nil {
+					affinityTags := make([]shared.AffinityTags, 0, len(r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags))
+					for affinityTagsIndex := range r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags {
 						var key3 string
-						key3 = affinityTagsItem.Key.ValueString()
+						key3 = r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags[affinityTagsIndex].Key.ValueString()
 
 						weight := new(int)
-						if !affinityTagsItem.Weight.IsUnknown() && !affinityTagsItem.Weight.IsNull() {
-							*weight = int(affinityTagsItem.Weight.ValueInt32())
+						if !r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags[affinityTagsIndex].Weight.IsUnknown() && !r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags[affinityTagsIndex].Weight.IsNull() {
+							*weight = int(r.Spec.To[toIndex].Default.LocalityAwareness.LocalZone.AffinityTags[affinityTagsIndex].Weight.ValueInt32())
 						} else {
 							weight = nil
 						}
@@ -933,46 +933,46 @@ func (r *MeshLoadBalancingStrategyResourceModel) ToSharedMeshLoadBalancingStrate
 				LocalityAwareness: localityAwareness,
 			}
 		}
-		kind1 := shared.MeshLoadBalancingStrategyItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind1 := shared.MeshLoadBalancingStrategyItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range toItem.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
 		mesh2 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh2 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh2 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh2 = nil
 		}
 		name11 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name11 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name11 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name11 = nil
 		}
 		namespace1 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace1 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace1 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace1 = nil
 		}
-		proxyTypes1 := make([]shared.MeshLoadBalancingStrategyItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem1 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes1 := make([]shared.MeshLoadBalancingStrategyItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem1 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes1 = append(proxyTypes1, shared.MeshLoadBalancingStrategyItemSpecProxyTypes(proxyTypesItem1.ValueString()))
 		}
 		sectionName1 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName1 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName1 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range toItem.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}

--- a/internal/provider/meshmetric_resource.go
+++ b/internal/provider/meshmetric_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -79,9 +78,6 @@ func (r *MeshMetricResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshMetricResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -765,7 +758,10 @@ func (r *MeshMetricResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshmetric_resource_sdk.go
+++ b/internal/provider/meshmetric_resource_sdk.go
@@ -254,27 +254,27 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 	var defaultVar *shared.Default
 	if r.Spec.Default != nil {
 		applications := make([]shared.Applications, 0, len(r.Spec.Default.Applications))
-		for _, applicationsItem := range r.Spec.Default.Applications {
+		for applicationsIndex := range r.Spec.Default.Applications {
 			address := new(string)
-			if !applicationsItem.Address.IsUnknown() && !applicationsItem.Address.IsNull() {
-				*address = applicationsItem.Address.ValueString()
+			if !r.Spec.Default.Applications[applicationsIndex].Address.IsUnknown() && !r.Spec.Default.Applications[applicationsIndex].Address.IsNull() {
+				*address = r.Spec.Default.Applications[applicationsIndex].Address.ValueString()
 			} else {
 				address = nil
 			}
 			name1 := new(string)
-			if !applicationsItem.Name.IsUnknown() && !applicationsItem.Name.IsNull() {
-				*name1 = applicationsItem.Name.ValueString()
+			if !r.Spec.Default.Applications[applicationsIndex].Name.IsUnknown() && !r.Spec.Default.Applications[applicationsIndex].Name.IsNull() {
+				*name1 = r.Spec.Default.Applications[applicationsIndex].Name.ValueString()
 			} else {
 				name1 = nil
 			}
 			path := new(string)
-			if !applicationsItem.Path.IsUnknown() && !applicationsItem.Path.IsNull() {
-				*path = applicationsItem.Path.ValueString()
+			if !r.Spec.Default.Applications[applicationsIndex].Path.IsUnknown() && !r.Spec.Default.Applications[applicationsIndex].Path.IsNull() {
+				*path = r.Spec.Default.Applications[applicationsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
 			var port int
-			port = int(applicationsItem.Port.ValueInt32())
+			port = int(r.Spec.Default.Applications[applicationsIndex].Port.ValueInt32())
 
 			applications = append(applications, shared.Applications{
 				Address: address,
@@ -284,15 +284,15 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 			})
 		}
 		backends := make([]shared.MeshMetricItemBackends, 0, len(r.Spec.Default.Backends))
-		for _, backendsItem := range r.Spec.Default.Backends {
+		for backendsIndex := range r.Spec.Default.Backends {
 			var openTelemetry *shared.OpenTelemetry
-			if backendsItem.OpenTelemetry != nil {
+			if r.Spec.Default.Backends[backendsIndex].OpenTelemetry != nil {
 				var endpoint string
-				endpoint = backendsItem.OpenTelemetry.Endpoint.ValueString()
+				endpoint = r.Spec.Default.Backends[backendsIndex].OpenTelemetry.Endpoint.ValueString()
 
 				refreshInterval := new(string)
-				if !backendsItem.OpenTelemetry.RefreshInterval.IsUnknown() && !backendsItem.OpenTelemetry.RefreshInterval.IsNull() {
-					*refreshInterval = backendsItem.OpenTelemetry.RefreshInterval.ValueString()
+				if !r.Spec.Default.Backends[backendsIndex].OpenTelemetry.RefreshInterval.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].OpenTelemetry.RefreshInterval.IsNull() {
+					*refreshInterval = r.Spec.Default.Backends[backendsIndex].OpenTelemetry.RefreshInterval.ValueString()
 				} else {
 					refreshInterval = nil
 				}
@@ -302,30 +302,30 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 				}
 			}
 			var prometheus *shared.Prometheus
-			if backendsItem.Prometheus != nil {
+			if r.Spec.Default.Backends[backendsIndex].Prometheus != nil {
 				clientID := new(string)
-				if !backendsItem.Prometheus.ClientID.IsUnknown() && !backendsItem.Prometheus.ClientID.IsNull() {
-					*clientID = backendsItem.Prometheus.ClientID.ValueString()
+				if !r.Spec.Default.Backends[backendsIndex].Prometheus.ClientID.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Prometheus.ClientID.IsNull() {
+					*clientID = r.Spec.Default.Backends[backendsIndex].Prometheus.ClientID.ValueString()
 				} else {
 					clientID = nil
 				}
 				path1 := new(string)
-				if !backendsItem.Prometheus.Path.IsUnknown() && !backendsItem.Prometheus.Path.IsNull() {
-					*path1 = backendsItem.Prometheus.Path.ValueString()
+				if !r.Spec.Default.Backends[backendsIndex].Prometheus.Path.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Prometheus.Path.IsNull() {
+					*path1 = r.Spec.Default.Backends[backendsIndex].Prometheus.Path.ValueString()
 				} else {
 					path1 = nil
 				}
 				port1 := new(int)
-				if !backendsItem.Prometheus.Port.IsUnknown() && !backendsItem.Prometheus.Port.IsNull() {
-					*port1 = int(backendsItem.Prometheus.Port.ValueInt32())
+				if !r.Spec.Default.Backends[backendsIndex].Prometheus.Port.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Prometheus.Port.IsNull() {
+					*port1 = int(r.Spec.Default.Backends[backendsIndex].Prometheus.Port.ValueInt32())
 				} else {
 					port1 = nil
 				}
 				var tls *shared.MeshMetricItemTLS
-				if backendsItem.Prometheus.TLS != nil {
+				if r.Spec.Default.Backends[backendsIndex].Prometheus.TLS != nil {
 					mode := new(shared.MeshMetricItemMode)
-					if !backendsItem.Prometheus.TLS.Mode.IsUnknown() && !backendsItem.Prometheus.TLS.Mode.IsNull() {
-						*mode = shared.MeshMetricItemMode(backendsItem.Prometheus.TLS.Mode.ValueString())
+					if !r.Spec.Default.Backends[backendsIndex].Prometheus.TLS.Mode.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Prometheus.TLS.Mode.IsNull() {
+						*mode = shared.MeshMetricItemMode(r.Spec.Default.Backends[backendsIndex].Prometheus.TLS.Mode.ValueString())
 					} else {
 						mode = nil
 					}
@@ -340,7 +340,7 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 					TLS:      tls,
 				}
 			}
-			type1 := shared.MeshMetricItemSpecType(backendsItem.Type.ValueString())
+			type1 := shared.MeshMetricItemSpecType(r.Spec.Default.Backends[backendsIndex].Type.ValueString())
 			backends = append(backends, shared.MeshMetricItemBackends{
 				OpenTelemetry: openTelemetry,
 				Prometheus:    prometheus,
@@ -358,29 +358,29 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 			var profiles *shared.Profiles
 			if r.Spec.Default.Sidecar.Profiles != nil {
 				appendProfiles := make([]shared.AppendProfiles, 0, len(r.Spec.Default.Sidecar.Profiles.AppendProfiles))
-				for _, appendProfilesItem := range r.Spec.Default.Sidecar.Profiles.AppendProfiles {
-					name2 := shared.MeshMetricItemName(appendProfilesItem.Name.ValueString())
+				for appendProfilesIndex := range r.Spec.Default.Sidecar.Profiles.AppendProfiles {
+					name2 := shared.MeshMetricItemName(r.Spec.Default.Sidecar.Profiles.AppendProfiles[appendProfilesIndex].Name.ValueString())
 					appendProfiles = append(appendProfiles, shared.AppendProfiles{
 						Name: name2,
 					})
 				}
 				exclude := make([]shared.Exclude, 0, len(r.Spec.Default.Sidecar.Profiles.Exclude))
-				for _, excludeItem := range r.Spec.Default.Sidecar.Profiles.Exclude {
+				for excludeIndex := range r.Spec.Default.Sidecar.Profiles.Exclude {
 					var match string
-					match = excludeItem.Match.ValueString()
+					match = r.Spec.Default.Sidecar.Profiles.Exclude[excludeIndex].Match.ValueString()
 
-					type2 := shared.MeshMetricItemSpecDefaultType(excludeItem.Type.ValueString())
+					type2 := shared.MeshMetricItemSpecDefaultType(r.Spec.Default.Sidecar.Profiles.Exclude[excludeIndex].Type.ValueString())
 					exclude = append(exclude, shared.Exclude{
 						Match: match,
 						Type:  type2,
 					})
 				}
 				include := make([]shared.Include, 0, len(r.Spec.Default.Sidecar.Profiles.Include))
-				for _, includeItem := range r.Spec.Default.Sidecar.Profiles.Include {
+				for includeIndex := range r.Spec.Default.Sidecar.Profiles.Include {
 					var match1 string
-					match1 = includeItem.Match.ValueString()
+					match1 = r.Spec.Default.Sidecar.Profiles.Include[includeIndex].Match.ValueString()
 
-					type3 := shared.MeshMetricItemSpecDefaultSidecarType(includeItem.Type.ValueString())
+					type3 := shared.MeshMetricItemSpecDefaultSidecarType(r.Spec.Default.Sidecar.Profiles.Include[includeIndex].Type.ValueString())
 					include = append(include, shared.Include{
 						Match: match1,
 						Type:  type3,
@@ -407,9 +407,9 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshMetricItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -442,9 +442,9 @@ func (r *MeshMetricResourceModel) ToSharedMeshMetricItemInput(ctx context.Contex
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}

--- a/internal/provider/meshmultizoneservice_resource.go
+++ b/internal/provider/meshmultizoneservice_resource.go
@@ -25,10 +25,8 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
-	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -81,9 +79,6 @@ func (r *MeshMultiZoneServiceResource) Schema(ctx context.Context, req resource.
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -108,9 +103,6 @@ func (r *MeshMultiZoneServiceResource) Schema(ctx context.Context, req resource.
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -235,9 +227,6 @@ func (r *MeshMultiZoneServiceResource) Schema(ctx context.Context, req resource.
 												Computed: true,
 												MarkdownDescription: `message is a human readable message indicating details about the transition.` + "\n" +
 													`This may be an empty string.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(32768),
-												},
 											},
 											"reason": schema.StringAttribute{
 												Computed: true,
@@ -246,32 +235,17 @@ func (r *MeshMultiZoneServiceResource) Schema(ctx context.Context, req resource.
 													`and whether the values are considered a guaranteed API.` + "\n" +
 													`The value should be a CamelCase string.` + "\n" +
 													`This field may not be empty.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthBetween(1, 1024),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`), "must match pattern "+regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`).String()),
-												},
 											},
 											"status": schema.StringAttribute{
 												Computed: true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
-												Description: `status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]`,
-												Validators: []validator.String{
-													stringvalidator.OneOf(
-														"True",
-														"False",
-														"Unknown",
-													),
-												},
+												Description: `status of the condition, one of True, False, Unknown.`,
 											},
 											"type": schema.StringAttribute{
 												Computed:    true,
 												Description: `type of condition in CamelCase or in foo.example.com/CamelCase.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(316),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`), "must match pattern "+regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`).String()),
-												},
 											},
 										},
 									},
@@ -670,7 +644,10 @@ func (r *MeshMultiZoneServiceResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshmultizoneservice_resource_sdk.go
+++ b/internal/provider/meshmultizoneservice_resource_sdk.go
@@ -215,21 +215,21 @@ func (r *MeshMultiZoneServiceResourceModel) ToSharedMeshMultiZoneServiceItemInpu
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	ports := make([]shared.Ports, 0, len(r.Spec.Ports))
-	for _, portsItem := range r.Spec.Ports {
+	for portsIndex := range r.Spec.Ports {
 		appProtocol := new(string)
-		if !portsItem.AppProtocol.IsUnknown() && !portsItem.AppProtocol.IsNull() {
-			*appProtocol = portsItem.AppProtocol.ValueString()
+		if !r.Spec.Ports[portsIndex].AppProtocol.IsUnknown() && !r.Spec.Ports[portsIndex].AppProtocol.IsNull() {
+			*appProtocol = r.Spec.Ports[portsIndex].AppProtocol.ValueString()
 		} else {
 			appProtocol = nil
 		}
 		name1 := new(string)
-		if !portsItem.Name.IsUnknown() && !portsItem.Name.IsNull() {
-			*name1 = portsItem.Name.ValueString()
+		if !r.Spec.Ports[portsIndex].Name.IsUnknown() && !r.Spec.Ports[portsIndex].Name.IsNull() {
+			*name1 = r.Spec.Ports[portsIndex].Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		var port int
-		port = int(portsItem.Port.ValueInt32())
+		port = int(r.Spec.Ports[portsIndex].Port.ValueInt32())
 
 		ports = append(ports, shared.Ports{
 			AppProtocol: appProtocol,
@@ -238,9 +238,9 @@ func (r *MeshMultiZoneServiceResourceModel) ToSharedMeshMultiZoneServiceItemInpu
 		})
 	}
 	matchLabels := make(map[string]string)
-	for matchLabelsKey, matchLabelsValue := range r.Spec.Selector.MeshService.MatchLabels {
+	for matchLabelsKey := range r.Spec.Selector.MeshService.MatchLabels {
 		var matchLabelsInst string
-		matchLabelsInst = matchLabelsValue.ValueString()
+		matchLabelsInst = r.Spec.Selector.MeshService.MatchLabels[matchLabelsKey].ValueString()
 
 		matchLabels[matchLabelsKey] = matchLabelsInst
 	}

--- a/internal/provider/meshopa_resource.go
+++ b/internal/provider/meshopa_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 )
 
@@ -75,9 +74,6 @@ func (r *MeshOPAResource) Schema(ctx context.Context, req resource.SchemaRequest
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -102,9 +98,6 @@ func (r *MeshOPAResource) Schema(ctx context.Context, req resource.SchemaRequest
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -623,7 +616,10 @@ func (r *MeshOPAResource) Delete(ctx context.Context, req resource.DeleteRequest
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshopa_resource_sdk.go
+++ b/internal/provider/meshopa_resource_sdk.go
@@ -233,28 +233,28 @@ func (r *MeshOPAResourceModel) ToSharedMeshOPAItemInput(ctx context.Context) (*s
 			}
 		}
 		appendPolicies := make([]shared.AppendPolicies, 0, len(r.Spec.Default.AppendPolicies))
-		for _, appendPoliciesItem := range r.Spec.Default.AppendPolicies {
+		for appendPoliciesIndex := range r.Spec.Default.AppendPolicies {
 			ignoreDecision := new(bool)
-			if !appendPoliciesItem.IgnoreDecision.IsUnknown() && !appendPoliciesItem.IgnoreDecision.IsNull() {
-				*ignoreDecision = appendPoliciesItem.IgnoreDecision.ValueBool()
+			if !r.Spec.Default.AppendPolicies[appendPoliciesIndex].IgnoreDecision.IsUnknown() && !r.Spec.Default.AppendPolicies[appendPoliciesIndex].IgnoreDecision.IsNull() {
+				*ignoreDecision = r.Spec.Default.AppendPolicies[appendPoliciesIndex].IgnoreDecision.ValueBool()
 			} else {
 				ignoreDecision = nil
 			}
 			inline1 := new(string)
-			if !appendPoliciesItem.Rego.Inline.IsUnknown() && !appendPoliciesItem.Rego.Inline.IsNull() {
-				*inline1 = appendPoliciesItem.Rego.Inline.ValueString()
+			if !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Inline.IsUnknown() && !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Inline.IsNull() {
+				*inline1 = r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Inline.ValueString()
 			} else {
 				inline1 = nil
 			}
 			inlineString1 := new(string)
-			if !appendPoliciesItem.Rego.InlineString.IsUnknown() && !appendPoliciesItem.Rego.InlineString.IsNull() {
-				*inlineString1 = appendPoliciesItem.Rego.InlineString.ValueString()
+			if !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.InlineString.IsUnknown() && !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.InlineString.IsNull() {
+				*inlineString1 = r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.InlineString.ValueString()
 			} else {
 				inlineString1 = nil
 			}
 			secret1 := new(string)
-			if !appendPoliciesItem.Rego.Secret.IsUnknown() && !appendPoliciesItem.Rego.Secret.IsNull() {
-				*secret1 = appendPoliciesItem.Rego.Secret.ValueString()
+			if !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Secret.IsUnknown() && !r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Secret.IsNull() {
+				*secret1 = r.Spec.Default.AppendPolicies[appendPoliciesIndex].Rego.Secret.ValueString()
 			} else {
 				secret1 = nil
 			}
@@ -324,9 +324,9 @@ func (r *MeshOPAResourceModel) ToSharedMeshOPAItemInput(ctx context.Context) (*s
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshOPAItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -359,9 +359,9 @@ func (r *MeshOPAResourceModel) ToSharedMeshOPAItemInput(ctx context.Context) (*s
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}

--- a/internal/provider/meshpassthrough_resource.go
+++ b/internal/provider/meshpassthrough_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -77,9 +76,6 @@ func (r *MeshPassthroughResource) Schema(ctx context.Context, req resource.Schem
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +100,6 @@ func (r *MeshPassthroughResource) Schema(ctx context.Context, req resource.Schem
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -593,7 +586,10 @@ func (r *MeshPassthroughResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshpassthrough_resource_sdk.go
+++ b/internal/provider/meshpassthrough_resource_sdk.go
@@ -189,22 +189,22 @@ func (r *MeshPassthroughResourceModel) ToSharedMeshPassthroughItemInput(ctx cont
 	var defaultVar *shared.MeshPassthroughItemDefault
 	if r.Spec.Default != nil {
 		appendMatch := make([]shared.AppendMatch, 0, len(r.Spec.Default.AppendMatch))
-		for _, appendMatchItem := range r.Spec.Default.AppendMatch {
+		for appendMatchIndex := range r.Spec.Default.AppendMatch {
 			port := new(int)
-			if !appendMatchItem.Port.IsUnknown() && !appendMatchItem.Port.IsNull() {
-				*port = int(appendMatchItem.Port.ValueInt32())
+			if !r.Spec.Default.AppendMatch[appendMatchIndex].Port.IsUnknown() && !r.Spec.Default.AppendMatch[appendMatchIndex].Port.IsNull() {
+				*port = int(r.Spec.Default.AppendMatch[appendMatchIndex].Port.ValueInt32())
 			} else {
 				port = nil
 			}
 			protocol := new(shared.MeshPassthroughItemProtocol)
-			if !appendMatchItem.Protocol.IsUnknown() && !appendMatchItem.Protocol.IsNull() {
-				*protocol = shared.MeshPassthroughItemProtocol(appendMatchItem.Protocol.ValueString())
+			if !r.Spec.Default.AppendMatch[appendMatchIndex].Protocol.IsUnknown() && !r.Spec.Default.AppendMatch[appendMatchIndex].Protocol.IsNull() {
+				*protocol = shared.MeshPassthroughItemProtocol(r.Spec.Default.AppendMatch[appendMatchIndex].Protocol.ValueString())
 			} else {
 				protocol = nil
 			}
-			type1 := shared.MeshPassthroughItemSpecType(appendMatchItem.Type.ValueString())
+			type1 := shared.MeshPassthroughItemSpecType(r.Spec.Default.AppendMatch[appendMatchIndex].Type.ValueString())
 			var value string
-			value = appendMatchItem.Value.ValueString()
+			value = r.Spec.Default.AppendMatch[appendMatchIndex].Value.ValueString()
 
 			appendMatch = append(appendMatch, shared.AppendMatch{
 				Port:     port,
@@ -228,9 +228,9 @@ func (r *MeshPassthroughResourceModel) ToSharedMeshPassthroughItemInput(ctx cont
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshPassthroughItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -263,9 +263,9 @@ func (r *MeshPassthroughResourceModel) ToSharedMeshPassthroughItemInput(ctx cont
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}

--- a/internal/provider/meshproxypatch_resource.go
+++ b/internal/provider/meshproxypatch_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -77,9 +76,6 @@ func (r *MeshProxyPatchResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +100,6 @@ func (r *MeshProxyPatchResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1054,7 +1047,10 @@ func (r *MeshProxyPatchResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshproxypatch_resource_sdk.go
+++ b/internal/provider/meshproxypatch_resource_sdk.go
@@ -342,24 +342,24 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	appendModifications := make([]shared.AppendModifications, 0, len(r.Spec.Default.AppendModifications))
-	for _, appendModificationsItem := range r.Spec.Default.AppendModifications {
+	for appendModificationsIndex := range r.Spec.Default.AppendModifications {
 		var cluster *shared.Cluster
-		if appendModificationsItem.Cluster != nil {
-			jsonPatches := make([]shared.JSONPatches, 0, len(appendModificationsItem.Cluster.JSONPatches))
-			for _, jsonPatchesItem := range appendModificationsItem.Cluster.JSONPatches {
+		if r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster != nil {
+			jsonPatches := make([]shared.JSONPatches, 0, len(r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches))
+			for jsonPatchesIndex := range r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches {
 				from := new(string)
-				if !jsonPatchesItem.From.IsUnknown() && !jsonPatchesItem.From.IsNull() {
-					*from = jsonPatchesItem.From.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].From.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].From.IsNull() {
+					*from = r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].From.ValueString()
 				} else {
 					from = nil
 				}
-				op := shared.Op(jsonPatchesItem.Op.ValueString())
+				op := shared.Op(r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].Op.ValueString())
 				var path string
-				path = jsonPatchesItem.Path.ValueString()
+				path = r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].Path.ValueString()
 
 				var value interface{}
-				if !jsonPatchesItem.Value.IsUnknown() && !jsonPatchesItem.Value.IsNull() {
-					_ = json.Unmarshal([]byte(jsonPatchesItem.Value.ValueString()), &value)
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].Value.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.JSONPatches[jsonPatchesIndex].Value.ValueString()), &value)
 				}
 				jsonPatches = append(jsonPatches, shared.JSONPatches{
 					From:  from,
@@ -369,16 +369,16 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				})
 			}
 			var match *shared.MeshProxyPatchItemSpecDefaultAppendModificationsClusterMatch
-			if appendModificationsItem.Cluster.Match != nil {
+			if r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match != nil {
 				name1 := new(string)
-				if !appendModificationsItem.Cluster.Match.Name.IsUnknown() && !appendModificationsItem.Cluster.Match.Name.IsNull() {
-					*name1 = appendModificationsItem.Cluster.Match.Name.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Name.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Name.IsNull() {
+					*name1 = r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Name.ValueString()
 				} else {
 					name1 = nil
 				}
 				origin := new(string)
-				if !appendModificationsItem.Cluster.Match.Origin.IsUnknown() && !appendModificationsItem.Cluster.Match.Origin.IsNull() {
-					*origin = appendModificationsItem.Cluster.Match.Origin.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Origin.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Origin.IsNull() {
+					*origin = r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Match.Origin.ValueString()
 				} else {
 					origin = nil
 				}
@@ -387,10 +387,10 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 					Origin: origin,
 				}
 			}
-			operation := shared.Operation(appendModificationsItem.Cluster.Operation.ValueString())
+			operation := shared.Operation(r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Operation.ValueString())
 			value1 := new(string)
-			if !appendModificationsItem.Cluster.Value.IsUnknown() && !appendModificationsItem.Cluster.Value.IsNull() {
-				*value1 = appendModificationsItem.Cluster.Value.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Value.IsNull() {
+				*value1 = r.Spec.Default.AppendModifications[appendModificationsIndex].Cluster.Value.ValueString()
 			} else {
 				value1 = nil
 			}
@@ -402,22 +402,22 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 			}
 		}
 		var httpFilter *shared.HTTPFilter
-		if appendModificationsItem.HTTPFilter != nil {
-			jsonPatches1 := make([]shared.MeshProxyPatchItemJSONPatches, 0, len(appendModificationsItem.HTTPFilter.JSONPatches))
-			for _, jsonPatchesItem1 := range appendModificationsItem.HTTPFilter.JSONPatches {
+		if r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter != nil {
+			jsonPatches1 := make([]shared.MeshProxyPatchItemJSONPatches, 0, len(r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches))
+			for jsonPatchesIndex1 := range r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches {
 				from1 := new(string)
-				if !jsonPatchesItem1.From.IsUnknown() && !jsonPatchesItem1.From.IsNull() {
-					*from1 = jsonPatchesItem1.From.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].From.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].From.IsNull() {
+					*from1 = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].From.ValueString()
 				} else {
 					from1 = nil
 				}
-				op1 := shared.MeshProxyPatchItemOp(jsonPatchesItem1.Op.ValueString())
+				op1 := shared.MeshProxyPatchItemOp(r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].Op.ValueString())
 				var path1 string
-				path1 = jsonPatchesItem1.Path.ValueString()
+				path1 = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].Path.ValueString()
 
 				var value2 interface{}
-				if !jsonPatchesItem1.Value.IsUnknown() && !jsonPatchesItem1.Value.IsNull() {
-					_ = json.Unmarshal([]byte(jsonPatchesItem1.Value.ValueString()), &value2)
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].Value.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.JSONPatches[jsonPatchesIndex1].Value.ValueString()), &value2)
 				}
 				jsonPatches1 = append(jsonPatches1, shared.MeshProxyPatchItemJSONPatches{
 					From:  from1,
@@ -427,29 +427,29 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				})
 			}
 			var match1 *shared.MeshProxyPatchItemMatch
-			if appendModificationsItem.HTTPFilter.Match != nil {
+			if r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match != nil {
 				listenerName := new(string)
-				if !appendModificationsItem.HTTPFilter.Match.ListenerName.IsUnknown() && !appendModificationsItem.HTTPFilter.Match.ListenerName.IsNull() {
-					*listenerName = appendModificationsItem.HTTPFilter.Match.ListenerName.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.ListenerName.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.ListenerName.IsNull() {
+					*listenerName = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.ListenerName.ValueString()
 				} else {
 					listenerName = nil
 				}
 				listenerTags := make(map[string]string)
-				for listenerTagsKey, listenerTagsValue := range appendModificationsItem.HTTPFilter.Match.ListenerTags {
+				for listenerTagsKey := range r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.ListenerTags {
 					var listenerTagsInst string
-					listenerTagsInst = listenerTagsValue.ValueString()
+					listenerTagsInst = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.ListenerTags[listenerTagsKey].ValueString()
 
 					listenerTags[listenerTagsKey] = listenerTagsInst
 				}
 				name2 := new(string)
-				if !appendModificationsItem.HTTPFilter.Match.Name.IsUnknown() && !appendModificationsItem.HTTPFilter.Match.Name.IsNull() {
-					*name2 = appendModificationsItem.HTTPFilter.Match.Name.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Name.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Name.IsNull() {
+					*name2 = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Name.ValueString()
 				} else {
 					name2 = nil
 				}
 				origin1 := new(string)
-				if !appendModificationsItem.HTTPFilter.Match.Origin.IsUnknown() && !appendModificationsItem.HTTPFilter.Match.Origin.IsNull() {
-					*origin1 = appendModificationsItem.HTTPFilter.Match.Origin.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Origin.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Origin.IsNull() {
+					*origin1 = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Match.Origin.ValueString()
 				} else {
 					origin1 = nil
 				}
@@ -460,10 +460,10 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 					Origin:       origin1,
 				}
 			}
-			operation1 := shared.MeshProxyPatchItemOperation(appendModificationsItem.HTTPFilter.Operation.ValueString())
+			operation1 := shared.MeshProxyPatchItemOperation(r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Operation.ValueString())
 			value3 := new(string)
-			if !appendModificationsItem.HTTPFilter.Value.IsUnknown() && !appendModificationsItem.HTTPFilter.Value.IsNull() {
-				*value3 = appendModificationsItem.HTTPFilter.Value.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Value.IsNull() {
+				*value3 = r.Spec.Default.AppendModifications[appendModificationsIndex].HTTPFilter.Value.ValueString()
 			} else {
 				value3 = nil
 			}
@@ -475,22 +475,22 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 			}
 		}
 		var listener *shared.Listener
-		if appendModificationsItem.Listener != nil {
-			jsonPatches2 := make([]shared.MeshProxyPatchItemSpecJSONPatches, 0, len(appendModificationsItem.Listener.JSONPatches))
-			for _, jsonPatchesItem2 := range appendModificationsItem.Listener.JSONPatches {
+		if r.Spec.Default.AppendModifications[appendModificationsIndex].Listener != nil {
+			jsonPatches2 := make([]shared.MeshProxyPatchItemSpecJSONPatches, 0, len(r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches))
+			for jsonPatchesIndex2 := range r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches {
 				from2 := new(string)
-				if !jsonPatchesItem2.From.IsUnknown() && !jsonPatchesItem2.From.IsNull() {
-					*from2 = jsonPatchesItem2.From.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].From.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].From.IsNull() {
+					*from2 = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].From.ValueString()
 				} else {
 					from2 = nil
 				}
-				op2 := shared.MeshProxyPatchItemSpecOp(jsonPatchesItem2.Op.ValueString())
+				op2 := shared.MeshProxyPatchItemSpecOp(r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].Op.ValueString())
 				var path2 string
-				path2 = jsonPatchesItem2.Path.ValueString()
+				path2 = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].Path.ValueString()
 
 				var value4 interface{}
-				if !jsonPatchesItem2.Value.IsUnknown() && !jsonPatchesItem2.Value.IsNull() {
-					_ = json.Unmarshal([]byte(jsonPatchesItem2.Value.ValueString()), &value4)
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].Value.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.JSONPatches[jsonPatchesIndex2].Value.ValueString()), &value4)
 				}
 				jsonPatches2 = append(jsonPatches2, shared.MeshProxyPatchItemSpecJSONPatches{
 					From:  from2,
@@ -500,23 +500,23 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				})
 			}
 			var match2 *shared.MeshProxyPatchItemSpecMatch
-			if appendModificationsItem.Listener.Match != nil {
+			if r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match != nil {
 				name3 := new(string)
-				if !appendModificationsItem.Listener.Match.Name.IsUnknown() && !appendModificationsItem.Listener.Match.Name.IsNull() {
-					*name3 = appendModificationsItem.Listener.Match.Name.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Name.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Name.IsNull() {
+					*name3 = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Name.ValueString()
 				} else {
 					name3 = nil
 				}
 				origin2 := new(string)
-				if !appendModificationsItem.Listener.Match.Origin.IsUnknown() && !appendModificationsItem.Listener.Match.Origin.IsNull() {
-					*origin2 = appendModificationsItem.Listener.Match.Origin.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Origin.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Origin.IsNull() {
+					*origin2 = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Origin.ValueString()
 				} else {
 					origin2 = nil
 				}
 				tags := make(map[string]string)
-				for tagsKey, tagsValue := range appendModificationsItem.Listener.Match.Tags {
+				for tagsKey := range r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Tags {
 					var tagsInst string
-					tagsInst = tagsValue.ValueString()
+					tagsInst = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Match.Tags[tagsKey].ValueString()
 
 					tags[tagsKey] = tagsInst
 				}
@@ -526,10 +526,10 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 					Tags:   tags,
 				}
 			}
-			operation2 := shared.MeshProxyPatchItemSpecOperation(appendModificationsItem.Listener.Operation.ValueString())
+			operation2 := shared.MeshProxyPatchItemSpecOperation(r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Operation.ValueString())
 			value5 := new(string)
-			if !appendModificationsItem.Listener.Value.IsUnknown() && !appendModificationsItem.Listener.Value.IsNull() {
-				*value5 = appendModificationsItem.Listener.Value.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Value.IsNull() {
+				*value5 = r.Spec.Default.AppendModifications[appendModificationsIndex].Listener.Value.ValueString()
 			} else {
 				value5 = nil
 			}
@@ -541,22 +541,22 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 			}
 		}
 		var networkFilter *shared.NetworkFilter
-		if appendModificationsItem.NetworkFilter != nil {
-			jsonPatches3 := make([]shared.MeshProxyPatchItemSpecDefaultJSONPatches, 0, len(appendModificationsItem.NetworkFilter.JSONPatches))
-			for _, jsonPatchesItem3 := range appendModificationsItem.NetworkFilter.JSONPatches {
+		if r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter != nil {
+			jsonPatches3 := make([]shared.MeshProxyPatchItemSpecDefaultJSONPatches, 0, len(r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches))
+			for jsonPatchesIndex3 := range r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches {
 				from3 := new(string)
-				if !jsonPatchesItem3.From.IsUnknown() && !jsonPatchesItem3.From.IsNull() {
-					*from3 = jsonPatchesItem3.From.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].From.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].From.IsNull() {
+					*from3 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].From.ValueString()
 				} else {
 					from3 = nil
 				}
-				op3 := shared.MeshProxyPatchItemSpecDefaultOp(jsonPatchesItem3.Op.ValueString())
+				op3 := shared.MeshProxyPatchItemSpecDefaultOp(r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].Op.ValueString())
 				var path3 string
-				path3 = jsonPatchesItem3.Path.ValueString()
+				path3 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].Path.ValueString()
 
 				var value6 interface{}
-				if !jsonPatchesItem3.Value.IsUnknown() && !jsonPatchesItem3.Value.IsNull() {
-					_ = json.Unmarshal([]byte(jsonPatchesItem3.Value.ValueString()), &value6)
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].Value.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.JSONPatches[jsonPatchesIndex3].Value.ValueString()), &value6)
 				}
 				jsonPatches3 = append(jsonPatches3, shared.MeshProxyPatchItemSpecDefaultJSONPatches{
 					From:  from3,
@@ -566,29 +566,29 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				})
 			}
 			var match3 *shared.MeshProxyPatchItemSpecDefaultMatch
-			if appendModificationsItem.NetworkFilter.Match != nil {
+			if r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match != nil {
 				listenerName1 := new(string)
-				if !appendModificationsItem.NetworkFilter.Match.ListenerName.IsUnknown() && !appendModificationsItem.NetworkFilter.Match.ListenerName.IsNull() {
-					*listenerName1 = appendModificationsItem.NetworkFilter.Match.ListenerName.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.ListenerName.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.ListenerName.IsNull() {
+					*listenerName1 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.ListenerName.ValueString()
 				} else {
 					listenerName1 = nil
 				}
 				listenerTags1 := make(map[string]string)
-				for listenerTagsKey1, listenerTagsValue1 := range appendModificationsItem.NetworkFilter.Match.ListenerTags {
+				for listenerTagsKey1 := range r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.ListenerTags {
 					var listenerTagsInst1 string
-					listenerTagsInst1 = listenerTagsValue1.ValueString()
+					listenerTagsInst1 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.ListenerTags[listenerTagsKey1].ValueString()
 
 					listenerTags1[listenerTagsKey1] = listenerTagsInst1
 				}
 				name4 := new(string)
-				if !appendModificationsItem.NetworkFilter.Match.Name.IsUnknown() && !appendModificationsItem.NetworkFilter.Match.Name.IsNull() {
-					*name4 = appendModificationsItem.NetworkFilter.Match.Name.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Name.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Name.IsNull() {
+					*name4 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Name.ValueString()
 				} else {
 					name4 = nil
 				}
 				origin3 := new(string)
-				if !appendModificationsItem.NetworkFilter.Match.Origin.IsUnknown() && !appendModificationsItem.NetworkFilter.Match.Origin.IsNull() {
-					*origin3 = appendModificationsItem.NetworkFilter.Match.Origin.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Origin.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Origin.IsNull() {
+					*origin3 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Match.Origin.ValueString()
 				} else {
 					origin3 = nil
 				}
@@ -599,10 +599,10 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 					Origin:       origin3,
 				}
 			}
-			operation3 := shared.MeshProxyPatchItemSpecDefaultOperation(appendModificationsItem.NetworkFilter.Operation.ValueString())
+			operation3 := shared.MeshProxyPatchItemSpecDefaultOperation(r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Operation.ValueString())
 			value7 := new(string)
-			if !appendModificationsItem.NetworkFilter.Value.IsUnknown() && !appendModificationsItem.NetworkFilter.Value.IsNull() {
-				*value7 = appendModificationsItem.NetworkFilter.Value.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Value.IsNull() {
+				*value7 = r.Spec.Default.AppendModifications[appendModificationsIndex].NetworkFilter.Value.ValueString()
 			} else {
 				value7 = nil
 			}
@@ -614,22 +614,22 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 			}
 		}
 		var virtualHost *shared.VirtualHost
-		if appendModificationsItem.VirtualHost != nil {
-			jsonPatches4 := make([]shared.MeshProxyPatchItemSpecDefaultAppendModificationsJSONPatches, 0, len(appendModificationsItem.VirtualHost.JSONPatches))
-			for _, jsonPatchesItem4 := range appendModificationsItem.VirtualHost.JSONPatches {
+		if r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost != nil {
+			jsonPatches4 := make([]shared.MeshProxyPatchItemSpecDefaultAppendModificationsJSONPatches, 0, len(r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches))
+			for jsonPatchesIndex4 := range r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches {
 				from4 := new(string)
-				if !jsonPatchesItem4.From.IsUnknown() && !jsonPatchesItem4.From.IsNull() {
-					*from4 = jsonPatchesItem4.From.ValueString()
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].From.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].From.IsNull() {
+					*from4 = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].From.ValueString()
 				} else {
 					from4 = nil
 				}
-				op4 := shared.MeshProxyPatchItemSpecDefaultAppendModificationsOp(jsonPatchesItem4.Op.ValueString())
+				op4 := shared.MeshProxyPatchItemSpecDefaultAppendModificationsOp(r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].Op.ValueString())
 				var path4 string
-				path4 = jsonPatchesItem4.Path.ValueString()
+				path4 = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].Path.ValueString()
 
 				var value8 interface{}
-				if !jsonPatchesItem4.Value.IsUnknown() && !jsonPatchesItem4.Value.IsNull() {
-					_ = json.Unmarshal([]byte(jsonPatchesItem4.Value.ValueString()), &value8)
+				if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].Value.IsNull() {
+					_ = json.Unmarshal([]byte(r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.JSONPatches[jsonPatchesIndex4].Value.ValueString()), &value8)
 				}
 				jsonPatches4 = append(jsonPatches4, shared.MeshProxyPatchItemSpecDefaultAppendModificationsJSONPatches{
 					From:  from4,
@@ -639,20 +639,20 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				})
 			}
 			name5 := new(string)
-			if !appendModificationsItem.VirtualHost.Match.Name.IsUnknown() && !appendModificationsItem.VirtualHost.Match.Name.IsNull() {
-				*name5 = appendModificationsItem.VirtualHost.Match.Name.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Name.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Name.IsNull() {
+				*name5 = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Name.ValueString()
 			} else {
 				name5 = nil
 			}
 			origin4 := new(string)
-			if !appendModificationsItem.VirtualHost.Match.Origin.IsUnknown() && !appendModificationsItem.VirtualHost.Match.Origin.IsNull() {
-				*origin4 = appendModificationsItem.VirtualHost.Match.Origin.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Origin.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Origin.IsNull() {
+				*origin4 = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.Origin.ValueString()
 			} else {
 				origin4 = nil
 			}
 			routeConfigurationName := new(string)
-			if !appendModificationsItem.VirtualHost.Match.RouteConfigurationName.IsUnknown() && !appendModificationsItem.VirtualHost.Match.RouteConfigurationName.IsNull() {
-				*routeConfigurationName = appendModificationsItem.VirtualHost.Match.RouteConfigurationName.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.RouteConfigurationName.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.RouteConfigurationName.IsNull() {
+				*routeConfigurationName = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Match.RouteConfigurationName.ValueString()
 			} else {
 				routeConfigurationName = nil
 			}
@@ -661,10 +661,10 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 				Origin:                 origin4,
 				RouteConfigurationName: routeConfigurationName,
 			}
-			operation4 := shared.MeshProxyPatchItemSpecDefaultAppendModificationsOperation(appendModificationsItem.VirtualHost.Operation.ValueString())
+			operation4 := shared.MeshProxyPatchItemSpecDefaultAppendModificationsOperation(r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Operation.ValueString())
 			value9 := new(string)
-			if !appendModificationsItem.VirtualHost.Value.IsUnknown() && !appendModificationsItem.VirtualHost.Value.IsNull() {
-				*value9 = appendModificationsItem.VirtualHost.Value.ValueString()
+			if !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Value.IsUnknown() && !r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Value.IsNull() {
+				*value9 = r.Spec.Default.AppendModifications[appendModificationsIndex].VirtualHost.Value.ValueString()
 			} else {
 				value9 = nil
 			}
@@ -690,9 +690,9 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshProxyPatchItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -725,9 +725,9 @@ func (r *MeshProxyPatchResourceModel) ToSharedMeshProxyPatchItemInput(ctx contex
 			sectionName = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}

--- a/internal/provider/meshratelimit_resource.go
+++ b/internal/provider/meshratelimit_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -79,9 +78,6 @@ func (r *MeshRateLimitResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshRateLimitResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -1195,7 +1188,10 @@ func (r *MeshRateLimitResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshratelimit_resource_sdk.go
+++ b/internal/provider/meshratelimit_resource_sdk.go
@@ -428,43 +428,43 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshRateLimitItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshRateLimitItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			var local *shared.Local
-			if fromItem.Default.Local != nil {
+			if r.Spec.From[fromIndex].Default.Local != nil {
 				var http *shared.MeshRateLimitItemHTTP
-				if fromItem.Default.Local.HTTP != nil {
+				if r.Spec.From[fromIndex].Default.Local.HTTP != nil {
 					disabled := new(bool)
-					if !fromItem.Default.Local.HTTP.Disabled.IsUnknown() && !fromItem.Default.Local.HTTP.Disabled.IsNull() {
-						*disabled = fromItem.Default.Local.HTTP.Disabled.ValueBool()
+					if !r.Spec.From[fromIndex].Default.Local.HTTP.Disabled.IsUnknown() && !r.Spec.From[fromIndex].Default.Local.HTTP.Disabled.IsNull() {
+						*disabled = r.Spec.From[fromIndex].Default.Local.HTTP.Disabled.ValueBool()
 					} else {
 						disabled = nil
 					}
 					var onRateLimit *shared.MeshRateLimitItemSpecFromOnRateLimit
-					if fromItem.Default.Local.HTTP.OnRateLimit != nil {
+					if r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit != nil {
 						var headers *shared.MeshRateLimitItemHeaders
-						if fromItem.Default.Local.HTTP.OnRateLimit.Headers != nil {
-							add := make([]shared.MeshRateLimitItemAdd, 0, len(fromItem.Default.Local.HTTP.OnRateLimit.Headers.Add))
-							for _, addItem := range fromItem.Default.Local.HTTP.OnRateLimit.Headers.Add {
+						if r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers != nil {
+							add := make([]shared.MeshRateLimitItemAdd, 0, len(r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Add))
+							for addIndex := range r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Add {
 								var name1 string
-								name1 = addItem.Name.ValueString()
+								name1 = r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex].Name.ValueString()
 
 								var value string
-								value = addItem.Value.ValueString()
+								value = r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex].Value.ValueString()
 
 								add = append(add, shared.MeshRateLimitItemAdd{
 									Name:  name1,
 									Value: value,
 								})
 							}
-							set := make([]shared.MeshRateLimitItemSet, 0, len(fromItem.Default.Local.HTTP.OnRateLimit.Headers.Set))
-							for _, setItem := range fromItem.Default.Local.HTTP.OnRateLimit.Headers.Set {
+							set := make([]shared.MeshRateLimitItemSet, 0, len(r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Set))
+							for setIndex := range r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Set {
 								var name2 string
-								name2 = setItem.Name.ValueString()
+								name2 = r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex].Name.ValueString()
 
 								var value1 string
-								value1 = setItem.Value.ValueString()
+								value1 = r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex].Value.ValueString()
 
 								set = append(set, shared.MeshRateLimitItemSet{
 									Name:  name2,
@@ -477,8 +477,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 							}
 						}
 						status := new(int)
-						if !fromItem.Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !fromItem.Default.Local.HTTP.OnRateLimit.Status.IsNull() {
-							*status = int(fromItem.Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
+						if !r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Status.IsNull() {
+							*status = int(r.Spec.From[fromIndex].Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
 						} else {
 							status = nil
 						}
@@ -488,12 +488,12 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					var requestRate *shared.MeshRateLimitItemSpecFromRequestRate
-					if fromItem.Default.Local.HTTP.RequestRate != nil {
+					if r.Spec.From[fromIndex].Default.Local.HTTP.RequestRate != nil {
 						var interval string
-						interval = fromItem.Default.Local.HTTP.RequestRate.Interval.ValueString()
+						interval = r.Spec.From[fromIndex].Default.Local.HTTP.RequestRate.Interval.ValueString()
 
 						var num int
-						num = int(fromItem.Default.Local.HTTP.RequestRate.Num.ValueInt32())
+						num = int(r.Spec.From[fromIndex].Default.Local.HTTP.RequestRate.Num.ValueInt32())
 
 						requestRate = &shared.MeshRateLimitItemSpecFromRequestRate{
 							Interval: interval,
@@ -507,14 +507,14 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 					}
 				}
 				var tcp *shared.MeshRateLimitItemTCP
-				if fromItem.Default.Local.TCP != nil {
+				if r.Spec.From[fromIndex].Default.Local.TCP != nil {
 					var connectionRate *shared.ConnectionRate
-					if fromItem.Default.Local.TCP.ConnectionRate != nil {
+					if r.Spec.From[fromIndex].Default.Local.TCP.ConnectionRate != nil {
 						var interval1 string
-						interval1 = fromItem.Default.Local.TCP.ConnectionRate.Interval.ValueString()
+						interval1 = r.Spec.From[fromIndex].Default.Local.TCP.ConnectionRate.Interval.ValueString()
 
 						var num1 int
-						num1 = int(fromItem.Default.Local.TCP.ConnectionRate.Num.ValueInt32())
+						num1 = int(r.Spec.From[fromIndex].Default.Local.TCP.ConnectionRate.Num.ValueInt32())
 
 						connectionRate = &shared.ConnectionRate{
 							Interval: interval1,
@@ -522,8 +522,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					disabled1 := new(bool)
-					if !fromItem.Default.Local.TCP.Disabled.IsUnknown() && !fromItem.Default.Local.TCP.Disabled.IsNull() {
-						*disabled1 = fromItem.Default.Local.TCP.Disabled.ValueBool()
+					if !r.Spec.From[fromIndex].Default.Local.TCP.Disabled.IsUnknown() && !r.Spec.From[fromIndex].Default.Local.TCP.Disabled.IsNull() {
+						*disabled1 = r.Spec.From[fromIndex].Default.Local.TCP.Disabled.ValueBool()
 					} else {
 						disabled1 = nil
 					}
@@ -541,46 +541,46 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 				Local: local,
 			}
 		}
-		kind := shared.MeshRateLimitItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshRateLimitItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name3 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name3 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshRateLimitItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshRateLimitItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshRateLimitItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -600,43 +600,43 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 		})
 	}
 	rules := make([]shared.MeshRateLimitItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
+	for rulesIndex := range r.Spec.Rules {
 		var default1 *shared.MeshRateLimitItemSpecDefault
-		if rulesItem.Default != nil {
+		if r.Spec.Rules[rulesIndex].Default != nil {
 			var local1 *shared.MeshRateLimitItemLocal
-			if rulesItem.Default.Local != nil {
+			if r.Spec.Rules[rulesIndex].Default.Local != nil {
 				var http1 *shared.MeshRateLimitItemSpecHTTP
-				if rulesItem.Default.Local.HTTP != nil {
+				if r.Spec.Rules[rulesIndex].Default.Local.HTTP != nil {
 					disabled2 := new(bool)
-					if !rulesItem.Default.Local.HTTP.Disabled.IsUnknown() && !rulesItem.Default.Local.HTTP.Disabled.IsNull() {
-						*disabled2 = rulesItem.Default.Local.HTTP.Disabled.ValueBool()
+					if !r.Spec.Rules[rulesIndex].Default.Local.HTTP.Disabled.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Local.HTTP.Disabled.IsNull() {
+						*disabled2 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.Disabled.ValueBool()
 					} else {
 						disabled2 = nil
 					}
 					var onRateLimit1 *shared.MeshRateLimitItemOnRateLimit
-					if rulesItem.Default.Local.HTTP.OnRateLimit != nil {
+					if r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit != nil {
 						var headers1 *shared.MeshRateLimitItemSpecHeaders
-						if rulesItem.Default.Local.HTTP.OnRateLimit.Headers != nil {
-							add1 := make([]shared.MeshRateLimitItemSpecAdd, 0, len(rulesItem.Default.Local.HTTP.OnRateLimit.Headers.Add))
-							for _, addItem1 := range rulesItem.Default.Local.HTTP.OnRateLimit.Headers.Add {
+						if r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers != nil {
+							add1 := make([]shared.MeshRateLimitItemSpecAdd, 0, len(r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Add))
+							for addIndex1 := range r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Add {
 								var name4 string
-								name4 = addItem1.Name.ValueString()
+								name4 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex1].Name.ValueString()
 
 								var value2 string
-								value2 = addItem1.Value.ValueString()
+								value2 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex1].Value.ValueString()
 
 								add1 = append(add1, shared.MeshRateLimitItemSpecAdd{
 									Name:  name4,
 									Value: value2,
 								})
 							}
-							set1 := make([]shared.MeshRateLimitItemSpecSet, 0, len(rulesItem.Default.Local.HTTP.OnRateLimit.Headers.Set))
-							for _, setItem1 := range rulesItem.Default.Local.HTTP.OnRateLimit.Headers.Set {
+							set1 := make([]shared.MeshRateLimitItemSpecSet, 0, len(r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Set))
+							for setIndex1 := range r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Set {
 								var name5 string
-								name5 = setItem1.Name.ValueString()
+								name5 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex1].Name.ValueString()
 
 								var value3 string
-								value3 = setItem1.Value.ValueString()
+								value3 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex1].Value.ValueString()
 
 								set1 = append(set1, shared.MeshRateLimitItemSpecSet{
 									Name:  name5,
@@ -649,8 +649,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 							}
 						}
 						status1 := new(int)
-						if !rulesItem.Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !rulesItem.Default.Local.HTTP.OnRateLimit.Status.IsNull() {
-							*status1 = int(rulesItem.Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
+						if !r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Status.IsNull() {
+							*status1 = int(r.Spec.Rules[rulesIndex].Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
 						} else {
 							status1 = nil
 						}
@@ -660,12 +660,12 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					var requestRate1 *shared.MeshRateLimitItemRequestRate
-					if rulesItem.Default.Local.HTTP.RequestRate != nil {
+					if r.Spec.Rules[rulesIndex].Default.Local.HTTP.RequestRate != nil {
 						var interval2 string
-						interval2 = rulesItem.Default.Local.HTTP.RequestRate.Interval.ValueString()
+						interval2 = r.Spec.Rules[rulesIndex].Default.Local.HTTP.RequestRate.Interval.ValueString()
 
 						var num2 int
-						num2 = int(rulesItem.Default.Local.HTTP.RequestRate.Num.ValueInt32())
+						num2 = int(r.Spec.Rules[rulesIndex].Default.Local.HTTP.RequestRate.Num.ValueInt32())
 
 						requestRate1 = &shared.MeshRateLimitItemRequestRate{
 							Interval: interval2,
@@ -679,14 +679,14 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 					}
 				}
 				var tcp1 *shared.MeshRateLimitItemSpecTCP
-				if rulesItem.Default.Local.TCP != nil {
+				if r.Spec.Rules[rulesIndex].Default.Local.TCP != nil {
 					var connectionRate1 *shared.MeshRateLimitItemConnectionRate
-					if rulesItem.Default.Local.TCP.ConnectionRate != nil {
+					if r.Spec.Rules[rulesIndex].Default.Local.TCP.ConnectionRate != nil {
 						var interval3 string
-						interval3 = rulesItem.Default.Local.TCP.ConnectionRate.Interval.ValueString()
+						interval3 = r.Spec.Rules[rulesIndex].Default.Local.TCP.ConnectionRate.Interval.ValueString()
 
 						var num3 int
-						num3 = int(rulesItem.Default.Local.TCP.ConnectionRate.Num.ValueInt32())
+						num3 = int(r.Spec.Rules[rulesIndex].Default.Local.TCP.ConnectionRate.Num.ValueInt32())
 
 						connectionRate1 = &shared.MeshRateLimitItemConnectionRate{
 							Interval: interval3,
@@ -694,8 +694,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					disabled3 := new(bool)
-					if !rulesItem.Default.Local.TCP.Disabled.IsUnknown() && !rulesItem.Default.Local.TCP.Disabled.IsNull() {
-						*disabled3 = rulesItem.Default.Local.TCP.Disabled.ValueBool()
+					if !r.Spec.Rules[rulesIndex].Default.Local.TCP.Disabled.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Local.TCP.Disabled.IsNull() {
+						*disabled3 = r.Spec.Rules[rulesIndex].Default.Local.TCP.Disabled.ValueBool()
 					} else {
 						disabled3 = nil
 					}
@@ -721,9 +721,9 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshRateLimitItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -756,9 +756,9 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -774,43 +774,43 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 		}
 	}
 	to := make([]shared.MeshRateLimitItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var default2 *shared.MeshRateLimitItemSpecToDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			var local2 *shared.MeshRateLimitItemSpecLocal
-			if toItem.Default.Local != nil {
+			if r.Spec.To[toIndex].Default.Local != nil {
 				var http2 *shared.MeshRateLimitItemSpecToHTTP
-				if toItem.Default.Local.HTTP != nil {
+				if r.Spec.To[toIndex].Default.Local.HTTP != nil {
 					disabled4 := new(bool)
-					if !toItem.Default.Local.HTTP.Disabled.IsUnknown() && !toItem.Default.Local.HTTP.Disabled.IsNull() {
-						*disabled4 = toItem.Default.Local.HTTP.Disabled.ValueBool()
+					if !r.Spec.To[toIndex].Default.Local.HTTP.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.Local.HTTP.Disabled.IsNull() {
+						*disabled4 = r.Spec.To[toIndex].Default.Local.HTTP.Disabled.ValueBool()
 					} else {
 						disabled4 = nil
 					}
 					var onRateLimit2 *shared.MeshRateLimitItemSpecOnRateLimit
-					if toItem.Default.Local.HTTP.OnRateLimit != nil {
+					if r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit != nil {
 						var headers2 *shared.MeshRateLimitItemSpecToHeaders
-						if toItem.Default.Local.HTTP.OnRateLimit.Headers != nil {
-							add2 := make([]shared.MeshRateLimitItemSpecToAdd, 0, len(toItem.Default.Local.HTTP.OnRateLimit.Headers.Add))
-							for _, addItem2 := range toItem.Default.Local.HTTP.OnRateLimit.Headers.Add {
+						if r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers != nil {
+							add2 := make([]shared.MeshRateLimitItemSpecToAdd, 0, len(r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Add))
+							for addIndex2 := range r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Add {
 								var name7 string
-								name7 = addItem2.Name.ValueString()
+								name7 = r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex2].Name.ValueString()
 
 								var value4 string
-								value4 = addItem2.Value.ValueString()
+								value4 = r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Add[addIndex2].Value.ValueString()
 
 								add2 = append(add2, shared.MeshRateLimitItemSpecToAdd{
 									Name:  name7,
 									Value: value4,
 								})
 							}
-							set2 := make([]shared.MeshRateLimitItemSpecToSet, 0, len(toItem.Default.Local.HTTP.OnRateLimit.Headers.Set))
-							for _, setItem2 := range toItem.Default.Local.HTTP.OnRateLimit.Headers.Set {
+							set2 := make([]shared.MeshRateLimitItemSpecToSet, 0, len(r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Set))
+							for setIndex2 := range r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Set {
 								var name8 string
-								name8 = setItem2.Name.ValueString()
+								name8 = r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex2].Name.ValueString()
 
 								var value5 string
-								value5 = setItem2.Value.ValueString()
+								value5 = r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Headers.Set[setIndex2].Value.ValueString()
 
 								set2 = append(set2, shared.MeshRateLimitItemSpecToSet{
 									Name:  name8,
@@ -823,8 +823,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 							}
 						}
 						status2 := new(int)
-						if !toItem.Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !toItem.Default.Local.HTTP.OnRateLimit.Status.IsNull() {
-							*status2 = int(toItem.Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
+						if !r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Status.IsUnknown() && !r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Status.IsNull() {
+							*status2 = int(r.Spec.To[toIndex].Default.Local.HTTP.OnRateLimit.Status.ValueInt32())
 						} else {
 							status2 = nil
 						}
@@ -834,12 +834,12 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					var requestRate2 *shared.MeshRateLimitItemSpecRequestRate
-					if toItem.Default.Local.HTTP.RequestRate != nil {
+					if r.Spec.To[toIndex].Default.Local.HTTP.RequestRate != nil {
 						var interval4 string
-						interval4 = toItem.Default.Local.HTTP.RequestRate.Interval.ValueString()
+						interval4 = r.Spec.To[toIndex].Default.Local.HTTP.RequestRate.Interval.ValueString()
 
 						var num4 int
-						num4 = int(toItem.Default.Local.HTTP.RequestRate.Num.ValueInt32())
+						num4 = int(r.Spec.To[toIndex].Default.Local.HTTP.RequestRate.Num.ValueInt32())
 
 						requestRate2 = &shared.MeshRateLimitItemSpecRequestRate{
 							Interval: interval4,
@@ -853,14 +853,14 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 					}
 				}
 				var tcp2 *shared.MeshRateLimitItemSpecToTCP
-				if toItem.Default.Local.TCP != nil {
+				if r.Spec.To[toIndex].Default.Local.TCP != nil {
 					var connectionRate2 *shared.MeshRateLimitItemSpecConnectionRate
-					if toItem.Default.Local.TCP.ConnectionRate != nil {
+					if r.Spec.To[toIndex].Default.Local.TCP.ConnectionRate != nil {
 						var interval5 string
-						interval5 = toItem.Default.Local.TCP.ConnectionRate.Interval.ValueString()
+						interval5 = r.Spec.To[toIndex].Default.Local.TCP.ConnectionRate.Interval.ValueString()
 
 						var num5 int
-						num5 = int(toItem.Default.Local.TCP.ConnectionRate.Num.ValueInt32())
+						num5 = int(r.Spec.To[toIndex].Default.Local.TCP.ConnectionRate.Num.ValueInt32())
 
 						connectionRate2 = &shared.MeshRateLimitItemSpecConnectionRate{
 							Interval: interval5,
@@ -868,8 +868,8 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 						}
 					}
 					disabled5 := new(bool)
-					if !toItem.Default.Local.TCP.Disabled.IsUnknown() && !toItem.Default.Local.TCP.Disabled.IsNull() {
-						*disabled5 = toItem.Default.Local.TCP.Disabled.ValueBool()
+					if !r.Spec.To[toIndex].Default.Local.TCP.Disabled.IsUnknown() && !r.Spec.To[toIndex].Default.Local.TCP.Disabled.IsNull() {
+						*disabled5 = r.Spec.To[toIndex].Default.Local.TCP.Disabled.ValueBool()
 					} else {
 						disabled5 = nil
 					}
@@ -887,46 +887,46 @@ func (r *MeshRateLimitResourceModel) ToSharedMeshRateLimitItemInput(ctx context.
 				Local: local2,
 			}
 		}
-		kind2 := shared.MeshRateLimitItemSpecToKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshRateLimitItemSpecToKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name9 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name9 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name9 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name9 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshRateLimitItemSpecToProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshRateLimitItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshRateLimitItemSpecToProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshretry_resource.go
+++ b/internal/provider/meshretry_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 	"regexp"
@@ -79,9 +78,6 @@ func (r *MeshRetryResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshRetryResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -960,7 +953,10 @@ func (r *MeshRetryResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshretry_resource_sdk.go
+++ b/internal/provider/meshretry_resource_sdk.go
@@ -319,9 +319,9 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshRetryItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -354,9 +354,9 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -372,22 +372,22 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 		}
 	}
 	to := make([]shared.MeshRetryItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var defaultVar *shared.MeshRetryItemDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			var grpc *shared.MeshRetryItemGrpc
-			if toItem.Default.Grpc != nil {
+			if r.Spec.To[toIndex].Default.Grpc != nil {
 				var backOff *shared.BackOff
-				if toItem.Default.Grpc.BackOff != nil {
+				if r.Spec.To[toIndex].Default.Grpc.BackOff != nil {
 					baseInterval := new(string)
-					if !toItem.Default.Grpc.BackOff.BaseInterval.IsUnknown() && !toItem.Default.Grpc.BackOff.BaseInterval.IsNull() {
-						*baseInterval = toItem.Default.Grpc.BackOff.BaseInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.Grpc.BackOff.BaseInterval.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.BackOff.BaseInterval.IsNull() {
+						*baseInterval = r.Spec.To[toIndex].Default.Grpc.BackOff.BaseInterval.ValueString()
 					} else {
 						baseInterval = nil
 					}
 					maxInterval := new(string)
-					if !toItem.Default.Grpc.BackOff.MaxInterval.IsUnknown() && !toItem.Default.Grpc.BackOff.MaxInterval.IsNull() {
-						*maxInterval = toItem.Default.Grpc.BackOff.MaxInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.Grpc.BackOff.MaxInterval.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.BackOff.MaxInterval.IsNull() {
+						*maxInterval = r.Spec.To[toIndex].Default.Grpc.BackOff.MaxInterval.ValueString()
 					} else {
 						maxInterval = nil
 					}
@@ -397,30 +397,30 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 					}
 				}
 				numRetries := new(int)
-				if !toItem.Default.Grpc.NumRetries.IsUnknown() && !toItem.Default.Grpc.NumRetries.IsNull() {
-					*numRetries = int(toItem.Default.Grpc.NumRetries.ValueInt32())
+				if !r.Spec.To[toIndex].Default.Grpc.NumRetries.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.NumRetries.IsNull() {
+					*numRetries = int(r.Spec.To[toIndex].Default.Grpc.NumRetries.ValueInt32())
 				} else {
 					numRetries = nil
 				}
 				perTryTimeout := new(string)
-				if !toItem.Default.Grpc.PerTryTimeout.IsUnknown() && !toItem.Default.Grpc.PerTryTimeout.IsNull() {
-					*perTryTimeout = toItem.Default.Grpc.PerTryTimeout.ValueString()
+				if !r.Spec.To[toIndex].Default.Grpc.PerTryTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.PerTryTimeout.IsNull() {
+					*perTryTimeout = r.Spec.To[toIndex].Default.Grpc.PerTryTimeout.ValueString()
 				} else {
 					perTryTimeout = nil
 				}
 				var rateLimitedBackOff *shared.RateLimitedBackOff
-				if toItem.Default.Grpc.RateLimitedBackOff != nil {
+				if r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff != nil {
 					maxInterval1 := new(string)
-					if !toItem.Default.Grpc.RateLimitedBackOff.MaxInterval.IsUnknown() && !toItem.Default.Grpc.RateLimitedBackOff.MaxInterval.IsNull() {
-						*maxInterval1 = toItem.Default.Grpc.RateLimitedBackOff.MaxInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.MaxInterval.IsUnknown() && !r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.MaxInterval.IsNull() {
+						*maxInterval1 = r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.MaxInterval.ValueString()
 					} else {
 						maxInterval1 = nil
 					}
-					resetHeaders := make([]shared.ResetHeaders, 0, len(toItem.Default.Grpc.RateLimitedBackOff.ResetHeaders))
-					for _, resetHeadersItem := range toItem.Default.Grpc.RateLimitedBackOff.ResetHeaders {
-						format := shared.MeshRetryItemFormat(resetHeadersItem.Format.ValueString())
+					resetHeaders := make([]shared.ResetHeaders, 0, len(r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.ResetHeaders))
+					for resetHeadersIndex := range r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.ResetHeaders {
+						format := shared.MeshRetryItemFormat(r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.ResetHeaders[resetHeadersIndex].Format.ValueString())
 						var name2 string
-						name2 = resetHeadersItem.Name.ValueString()
+						name2 = r.Spec.To[toIndex].Default.Grpc.RateLimitedBackOff.ResetHeaders[resetHeadersIndex].Name.ValueString()
 
 						resetHeaders = append(resetHeaders, shared.ResetHeaders{
 							Format: format,
@@ -432,8 +432,8 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 						ResetHeaders: resetHeaders,
 					}
 				}
-				retryOn := make([]shared.RetryOn, 0, len(toItem.Default.Grpc.RetryOn))
-				for _, retryOnItem := range toItem.Default.Grpc.RetryOn {
+				retryOn := make([]shared.RetryOn, 0, len(r.Spec.To[toIndex].Default.Grpc.RetryOn))
+				for _, retryOnItem := range r.Spec.To[toIndex].Default.Grpc.RetryOn {
 					retryOn = append(retryOn, shared.RetryOn(retryOnItem.ValueString()))
 				}
 				grpc = &shared.MeshRetryItemGrpc{
@@ -445,18 +445,18 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 				}
 			}
 			var http *shared.MeshRetryItemHTTP
-			if toItem.Default.HTTP != nil {
+			if r.Spec.To[toIndex].Default.HTTP != nil {
 				var backOff1 *shared.MeshRetryItemBackOff
-				if toItem.Default.HTTP.BackOff != nil {
+				if r.Spec.To[toIndex].Default.HTTP.BackOff != nil {
 					baseInterval1 := new(string)
-					if !toItem.Default.HTTP.BackOff.BaseInterval.IsUnknown() && !toItem.Default.HTTP.BackOff.BaseInterval.IsNull() {
-						*baseInterval1 = toItem.Default.HTTP.BackOff.BaseInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP.BackOff.BaseInterval.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.BackOff.BaseInterval.IsNull() {
+						*baseInterval1 = r.Spec.To[toIndex].Default.HTTP.BackOff.BaseInterval.ValueString()
 					} else {
 						baseInterval1 = nil
 					}
 					maxInterval2 := new(string)
-					if !toItem.Default.HTTP.BackOff.MaxInterval.IsUnknown() && !toItem.Default.HTTP.BackOff.MaxInterval.IsNull() {
-						*maxInterval2 = toItem.Default.HTTP.BackOff.MaxInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP.BackOff.MaxInterval.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.BackOff.MaxInterval.IsNull() {
+						*maxInterval2 = r.Spec.To[toIndex].Default.HTTP.BackOff.MaxInterval.ValueString()
 					} else {
 						maxInterval2 = nil
 					}
@@ -465,19 +465,19 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 						MaxInterval:  maxInterval2,
 					}
 				}
-				hostSelection := make([]shared.HostSelection, 0, len(toItem.Default.HTTP.HostSelection))
-				for _, hostSelectionItem := range toItem.Default.HTTP.HostSelection {
-					predicate := shared.Predicate(hostSelectionItem.Predicate.ValueString())
+				hostSelection := make([]shared.HostSelection, 0, len(r.Spec.To[toIndex].Default.HTTP.HostSelection))
+				for hostSelectionIndex := range r.Spec.To[toIndex].Default.HTTP.HostSelection {
+					predicate := shared.Predicate(r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].Predicate.ValueString())
 					tags1 := make(map[string]string)
-					for tagsKey1, tagsValue1 := range hostSelectionItem.Tags {
+					for tagsKey1 := range r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].Tags {
 						var tagsInst1 string
-						tagsInst1 = tagsValue1.ValueString()
+						tagsInst1 = r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].Tags[tagsKey1].ValueString()
 
 						tags1[tagsKey1] = tagsInst1
 					}
 					updateFrequency := new(int)
-					if !hostSelectionItem.UpdateFrequency.IsUnknown() && !hostSelectionItem.UpdateFrequency.IsNull() {
-						*updateFrequency = int(hostSelectionItem.UpdateFrequency.ValueInt32())
+					if !r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].UpdateFrequency.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].UpdateFrequency.IsNull() {
+						*updateFrequency = int(r.Spec.To[toIndex].Default.HTTP.HostSelection[hostSelectionIndex].UpdateFrequency.ValueInt32())
 					} else {
 						updateFrequency = nil
 					}
@@ -488,36 +488,36 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 					})
 				}
 				hostSelectionMaxAttempts := new(int64)
-				if !toItem.Default.HTTP.HostSelectionMaxAttempts.IsUnknown() && !toItem.Default.HTTP.HostSelectionMaxAttempts.IsNull() {
-					*hostSelectionMaxAttempts = toItem.Default.HTTP.HostSelectionMaxAttempts.ValueInt64()
+				if !r.Spec.To[toIndex].Default.HTTP.HostSelectionMaxAttempts.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.HostSelectionMaxAttempts.IsNull() {
+					*hostSelectionMaxAttempts = r.Spec.To[toIndex].Default.HTTP.HostSelectionMaxAttempts.ValueInt64()
 				} else {
 					hostSelectionMaxAttempts = nil
 				}
 				numRetries1 := new(int)
-				if !toItem.Default.HTTP.NumRetries.IsUnknown() && !toItem.Default.HTTP.NumRetries.IsNull() {
-					*numRetries1 = int(toItem.Default.HTTP.NumRetries.ValueInt32())
+				if !r.Spec.To[toIndex].Default.HTTP.NumRetries.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.NumRetries.IsNull() {
+					*numRetries1 = int(r.Spec.To[toIndex].Default.HTTP.NumRetries.ValueInt32())
 				} else {
 					numRetries1 = nil
 				}
 				perTryTimeout1 := new(string)
-				if !toItem.Default.HTTP.PerTryTimeout.IsUnknown() && !toItem.Default.HTTP.PerTryTimeout.IsNull() {
-					*perTryTimeout1 = toItem.Default.HTTP.PerTryTimeout.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.PerTryTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.PerTryTimeout.IsNull() {
+					*perTryTimeout1 = r.Spec.To[toIndex].Default.HTTP.PerTryTimeout.ValueString()
 				} else {
 					perTryTimeout1 = nil
 				}
 				var rateLimitedBackOff1 *shared.MeshRetryItemRateLimitedBackOff
-				if toItem.Default.HTTP.RateLimitedBackOff != nil {
+				if r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff != nil {
 					maxInterval3 := new(string)
-					if !toItem.Default.HTTP.RateLimitedBackOff.MaxInterval.IsUnknown() && !toItem.Default.HTTP.RateLimitedBackOff.MaxInterval.IsNull() {
-						*maxInterval3 = toItem.Default.HTTP.RateLimitedBackOff.MaxInterval.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.MaxInterval.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.MaxInterval.IsNull() {
+						*maxInterval3 = r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.MaxInterval.ValueString()
 					} else {
 						maxInterval3 = nil
 					}
-					resetHeaders1 := make([]shared.MeshRetryItemResetHeaders, 0, len(toItem.Default.HTTP.RateLimitedBackOff.ResetHeaders))
-					for _, resetHeadersItem1 := range toItem.Default.HTTP.RateLimitedBackOff.ResetHeaders {
-						format1 := shared.MeshRetryItemSpecFormat(resetHeadersItem1.Format.ValueString())
+					resetHeaders1 := make([]shared.MeshRetryItemResetHeaders, 0, len(r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.ResetHeaders))
+					for resetHeadersIndex1 := range r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.ResetHeaders {
+						format1 := shared.MeshRetryItemSpecFormat(r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.ResetHeaders[resetHeadersIndex1].Format.ValueString())
 						var name3 string
-						name3 = resetHeadersItem1.Name.ValueString()
+						name3 = r.Spec.To[toIndex].Default.HTTP.RateLimitedBackOff.ResetHeaders[resetHeadersIndex1].Name.ValueString()
 
 						resetHeaders1 = append(resetHeaders1, shared.MeshRetryItemResetHeaders{
 							Format: format1,
@@ -529,20 +529,20 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 						ResetHeaders: resetHeaders1,
 					}
 				}
-				retriableRequestHeaders := make([]shared.RetriableRequestHeaders, 0, len(toItem.Default.HTTP.RetriableRequestHeaders))
-				for _, retriableRequestHeadersItem := range toItem.Default.HTTP.RetriableRequestHeaders {
+				retriableRequestHeaders := make([]shared.RetriableRequestHeaders, 0, len(r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders))
+				for retriableRequestHeadersIndex := range r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders {
 					var name4 string
-					name4 = retriableRequestHeadersItem.Name.ValueString()
+					name4 = r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Name.ValueString()
 
 					type1 := new(shared.MeshRetryItemSpecType)
-					if !retriableRequestHeadersItem.Type.IsUnknown() && !retriableRequestHeadersItem.Type.IsNull() {
-						*type1 = shared.MeshRetryItemSpecType(retriableRequestHeadersItem.Type.ValueString())
+					if !r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Type.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Type.IsNull() {
+						*type1 = shared.MeshRetryItemSpecType(r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Type.ValueString())
 					} else {
 						type1 = nil
 					}
 					value := new(string)
-					if !retriableRequestHeadersItem.Value.IsUnknown() && !retriableRequestHeadersItem.Value.IsNull() {
-						*value = retriableRequestHeadersItem.Value.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Value.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Value.IsNull() {
+						*value = r.Spec.To[toIndex].Default.HTTP.RetriableRequestHeaders[retriableRequestHeadersIndex].Value.ValueString()
 					} else {
 						value = nil
 					}
@@ -552,20 +552,20 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 						Value: value,
 					})
 				}
-				retriableResponseHeaders := make([]shared.RetriableResponseHeaders, 0, len(toItem.Default.HTTP.RetriableResponseHeaders))
-				for _, retriableResponseHeadersItem := range toItem.Default.HTTP.RetriableResponseHeaders {
+				retriableResponseHeaders := make([]shared.RetriableResponseHeaders, 0, len(r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders))
+				for retriableResponseHeadersIndex := range r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders {
 					var name5 string
-					name5 = retriableResponseHeadersItem.Name.ValueString()
+					name5 = r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Name.ValueString()
 
 					type2 := new(shared.MeshRetryItemSpecToType)
-					if !retriableResponseHeadersItem.Type.IsUnknown() && !retriableResponseHeadersItem.Type.IsNull() {
-						*type2 = shared.MeshRetryItemSpecToType(retriableResponseHeadersItem.Type.ValueString())
+					if !r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Type.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Type.IsNull() {
+						*type2 = shared.MeshRetryItemSpecToType(r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Type.ValueString())
 					} else {
 						type2 = nil
 					}
 					value1 := new(string)
-					if !retriableResponseHeadersItem.Value.IsUnknown() && !retriableResponseHeadersItem.Value.IsNull() {
-						*value1 = retriableResponseHeadersItem.Value.ValueString()
+					if !r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Value.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Value.IsNull() {
+						*value1 = r.Spec.To[toIndex].Default.HTTP.RetriableResponseHeaders[retriableResponseHeadersIndex].Value.ValueString()
 					} else {
 						value1 = nil
 					}
@@ -575,9 +575,9 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 						Value: value1,
 					})
 				}
-				retryOn1 := make([]string, 0, len(toItem.Default.HTTP.RetryOn))
-				for _, retryOnItem1 := range toItem.Default.HTTP.RetryOn {
-					retryOn1 = append(retryOn1, retryOnItem1.ValueString())
+				retryOn1 := make([]string, 0, len(r.Spec.To[toIndex].Default.HTTP.RetryOn))
+				for retryOnIndex := range r.Spec.To[toIndex].Default.HTTP.RetryOn {
+					retryOn1 = append(retryOn1, r.Spec.To[toIndex].Default.HTTP.RetryOn[retryOnIndex].ValueString())
 				}
 				http = &shared.MeshRetryItemHTTP{
 					BackOff:                  backOff1,
@@ -592,10 +592,10 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 				}
 			}
 			var tcp *shared.MeshRetryItemTCP
-			if toItem.Default.TCP != nil {
+			if r.Spec.To[toIndex].Default.TCP != nil {
 				maxConnectAttempt := new(int)
-				if !toItem.Default.TCP.MaxConnectAttempt.IsUnknown() && !toItem.Default.TCP.MaxConnectAttempt.IsNull() {
-					*maxConnectAttempt = int(toItem.Default.TCP.MaxConnectAttempt.ValueInt32())
+				if !r.Spec.To[toIndex].Default.TCP.MaxConnectAttempt.IsUnknown() && !r.Spec.To[toIndex].Default.TCP.MaxConnectAttempt.IsNull() {
+					*maxConnectAttempt = int(r.Spec.To[toIndex].Default.TCP.MaxConnectAttempt.ValueInt32())
 				} else {
 					maxConnectAttempt = nil
 				}
@@ -609,46 +609,46 @@ func (r *MeshRetryResourceModel) ToSharedMeshRetryItemInput(ctx context.Context)
 				TCP:  tcp,
 			}
 		}
-		kind1 := shared.MeshRetryItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind1 := shared.MeshRetryItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range toItem.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
 		mesh2 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh2 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh2 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh2 = nil
 		}
 		name6 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name6 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name6 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name6 = nil
 		}
 		namespace1 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace1 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace1 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace1 = nil
 		}
-		proxyTypes1 := make([]shared.MeshRetryItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem1 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes1 := make([]shared.MeshRetryItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem1 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes1 = append(proxyTypes1, shared.MeshRetryItemSpecProxyTypes(proxyTypesItem1.ValueString()))
 		}
 		sectionName1 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName1 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName1 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName1 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshsecret_resource.go
+++ b/internal/provider/meshsecret_resource.go
@@ -402,7 +402,10 @@ func (r *MeshSecretResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshservice_resource.go
+++ b/internal/provider/meshservice_resource.go
@@ -25,11 +25,9 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_int32validators "github.com/kong/terraform-provider-konnect-beta/internal/validators/int32validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
-	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -82,9 +80,6 @@ func (r *MeshServiceResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -109,9 +104,6 @@ func (r *MeshServiceResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -318,9 +310,6 @@ func (r *MeshServiceResource) Schema(ctx context.Context, req resource.SchemaReq
 												Computed: true,
 												MarkdownDescription: `message is a human readable message indicating details about the transition.` + "\n" +
 													`This may be an empty string.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(32768),
-												},
 											},
 											"reason": schema.StringAttribute{
 												Computed: true,
@@ -329,32 +318,17 @@ func (r *MeshServiceResource) Schema(ctx context.Context, req resource.SchemaReq
 													`and whether the values are considered a guaranteed API.` + "\n" +
 													`The value should be a CamelCase string.` + "\n" +
 													`This field may not be empty.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthBetween(1, 1024),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`), "must match pattern "+regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`).String()),
-												},
 											},
 											"status": schema.StringAttribute{
 												Computed: true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
-												Description: `status of the condition, one of True, False, Unknown. must be one of ["True", "False", "Unknown"]`,
-												Validators: []validator.String{
-													stringvalidator.OneOf(
-														"True",
-														"False",
-														"Unknown",
-													),
-												},
+												Description: `status of the condition, one of True, False, Unknown.`,
 											},
 											"type": schema.StringAttribute{
 												Computed:    true,
 												Description: `type of condition in CamelCase or in foo.example.com/CamelCase.`,
-												Validators: []validator.String{
-													stringvalidator.UTF8LengthAtMost(316),
-													stringvalidator.RegexMatches(regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`), "must match pattern "+regexp.MustCompile(`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`).String()),
-												},
 											},
 										},
 									},
@@ -378,13 +352,6 @@ func (r *MeshServiceResource) Schema(ctx context.Context, req resource.SchemaReq
 								Computed: true,
 								PlanModifiers: []planmodifier.String{
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-								},
-								Description: `must be one of ["Ready", "NotReady"]`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"Ready",
-										"NotReady",
-									),
 								},
 							},
 						},
@@ -741,7 +708,10 @@ func (r *MeshServiceResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshservice_resource_sdk.go
+++ b/internal/provider/meshservice_resource_sdk.go
@@ -256,10 +256,10 @@ func (r *MeshServiceResourceModel) ToSharedMeshServiceItemInput(ctx context.Cont
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	identities := make([]shared.Identities, 0, len(r.Spec.Identities))
-	for _, identitiesItem := range r.Spec.Identities {
-		type1 := shared.MeshServiceItemSpecType(identitiesItem.Type.ValueString())
+	for identitiesIndex := range r.Spec.Identities {
+		type1 := shared.MeshServiceItemSpecType(r.Spec.Identities[identitiesIndex].Type.ValueString())
 		var value string
-		value = identitiesItem.Value.ValueString()
+		value = r.Spec.Identities[identitiesIndex].Value.ValueString()
 
 		identities = append(identities, shared.Identities{
 			Type:  type1,
@@ -267,27 +267,27 @@ func (r *MeshServiceResourceModel) ToSharedMeshServiceItemInput(ctx context.Cont
 		})
 	}
 	ports := make([]shared.MeshServiceItemPorts, 0, len(r.Spec.Ports))
-	for _, portsItem := range r.Spec.Ports {
+	for portsIndex := range r.Spec.Ports {
 		appProtocol := new(string)
-		if !portsItem.AppProtocol.IsUnknown() && !portsItem.AppProtocol.IsNull() {
-			*appProtocol = portsItem.AppProtocol.ValueString()
+		if !r.Spec.Ports[portsIndex].AppProtocol.IsUnknown() && !r.Spec.Ports[portsIndex].AppProtocol.IsNull() {
+			*appProtocol = r.Spec.Ports[portsIndex].AppProtocol.ValueString()
 		} else {
 			appProtocol = nil
 		}
 		name1 := new(string)
-		if !portsItem.Name.IsUnknown() && !portsItem.Name.IsNull() {
-			*name1 = portsItem.Name.ValueString()
+		if !r.Spec.Ports[portsIndex].Name.IsUnknown() && !r.Spec.Ports[portsIndex].Name.IsNull() {
+			*name1 = r.Spec.Ports[portsIndex].Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		var port int
-		port = int(portsItem.Port.ValueInt32())
+		port = int(r.Spec.Ports[portsIndex].Port.ValueInt32())
 
 		var targetPort *shared.TargetPort
-		if portsItem.TargetPort != nil {
+		if r.Spec.Ports[portsIndex].TargetPort != nil {
 			integer := new(int64)
-			if !portsItem.TargetPort.Integer.IsUnknown() && !portsItem.TargetPort.Integer.IsNull() {
-				*integer = portsItem.TargetPort.Integer.ValueInt64()
+			if !r.Spec.Ports[portsIndex].TargetPort.Integer.IsUnknown() && !r.Spec.Ports[portsIndex].TargetPort.Integer.IsNull() {
+				*integer = r.Spec.Ports[portsIndex].TargetPort.Integer.ValueInt64()
 			} else {
 				integer = nil
 			}
@@ -297,8 +297,8 @@ func (r *MeshServiceResourceModel) ToSharedMeshServiceItemInput(ctx context.Cont
 				}
 			}
 			str := new(string)
-			if !portsItem.TargetPort.Str.IsUnknown() && !portsItem.TargetPort.Str.IsNull() {
-				*str = portsItem.TargetPort.Str.ValueString()
+			if !r.Spec.Ports[portsIndex].TargetPort.Str.IsUnknown() && !r.Spec.Ports[portsIndex].TargetPort.Str.IsNull() {
+				*str = r.Spec.Ports[portsIndex].TargetPort.Str.ValueString()
 			} else {
 				str = nil
 			}
@@ -330,9 +330,9 @@ func (r *MeshServiceResourceModel) ToSharedMeshServiceItemInput(ctx context.Cont
 			}
 		}
 		dataplaneTags := make(map[string]string)
-		for dataplaneTagsKey, dataplaneTagsValue := range r.Spec.Selector.DataplaneTags {
+		for dataplaneTagsKey := range r.Spec.Selector.DataplaneTags {
 			var dataplaneTagsInst string
-			dataplaneTagsInst = dataplaneTagsValue.ValueString()
+			dataplaneTagsInst = r.Spec.Selector.DataplaneTags[dataplaneTagsKey].ValueString()
 
 			dataplaneTags[dataplaneTagsKey] = dataplaneTagsInst
 		}

--- a/internal/provider/meshtcproute_resource.go
+++ b/internal/provider/meshtcproute_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_listvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
@@ -79,9 +78,6 @@ func (r *MeshTCPRouteResource) Schema(ctx context.Context, req resource.SchemaRe
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -106,9 +102,6 @@ func (r *MeshTCPRouteResource) Schema(ctx context.Context, req resource.SchemaRe
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -725,7 +718,10 @@ func (r *MeshTCPRouteResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtcproute_resource_sdk.go
+++ b/internal/provider/meshtcproute_resource_sdk.go
@@ -232,9 +232,9 @@ func (r *MeshTCPRouteResourceModel) ToSharedMeshTCPRouteItemInput(ctx context.Co
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshTCPRouteItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -267,9 +267,9 @@ func (r *MeshTCPRouteResourceModel) ToSharedMeshTCPRouteItemInput(ctx context.Co
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -285,63 +285,63 @@ func (r *MeshTCPRouteResourceModel) ToSharedMeshTCPRouteItemInput(ctx context.Co
 		}
 	}
 	to := make([]shared.MeshTCPRouteItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
-		rules := make([]shared.MeshTCPRouteItemRules, 0, len(toItem.Rules))
-		for _, rulesItem := range toItem.Rules {
-			backendRefs := make([]shared.MeshTCPRouteItemBackendRefs, 0, len(rulesItem.Default.BackendRefs))
-			for _, backendRefsItem := range rulesItem.Default.BackendRefs {
-				kind1 := shared.MeshTCPRouteItemSpecToKind(backendRefsItem.Kind.ValueString())
+	for toIndex := range r.Spec.To {
+		rules := make([]shared.MeshTCPRouteItemRules, 0, len(r.Spec.To[toIndex].Rules))
+		for rulesIndex := range r.Spec.To[toIndex].Rules {
+			backendRefs := make([]shared.MeshTCPRouteItemBackendRefs, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs))
+			for backendRefsIndex := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs {
+				kind1 := shared.MeshTCPRouteItemSpecToKind(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Kind.ValueString())
 				labels2 := make(map[string]string)
-				for labelsKey1, labelsValue1 := range backendRefsItem.Labels {
+				for labelsKey1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Labels {
 					var labelsInst1 string
-					labelsInst1 = labelsValue1.ValueString()
+					labelsInst1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Labels[labelsKey1].ValueString()
 
 					labels2[labelsKey1] = labelsInst1
 				}
 				mesh2 := new(string)
-				if !backendRefsItem.Mesh.IsUnknown() && !backendRefsItem.Mesh.IsNull() {
-					*mesh2 = backendRefsItem.Mesh.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.IsNull() {
+					*mesh2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Mesh.ValueString()
 				} else {
 					mesh2 = nil
 				}
 				name2 := new(string)
-				if !backendRefsItem.Name.IsUnknown() && !backendRefsItem.Name.IsNull() {
-					*name2 = backendRefsItem.Name.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.IsNull() {
+					*name2 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Name.ValueString()
 				} else {
 					name2 = nil
 				}
 				namespace1 := new(string)
-				if !backendRefsItem.Namespace.IsUnknown() && !backendRefsItem.Namespace.IsNull() {
-					*namespace1 = backendRefsItem.Namespace.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.IsNull() {
+					*namespace1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Namespace.ValueString()
 				} else {
 					namespace1 = nil
 				}
 				port := new(int)
-				if !backendRefsItem.Port.IsUnknown() && !backendRefsItem.Port.IsNull() {
-					*port = int(backendRefsItem.Port.ValueInt32())
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.IsNull() {
+					*port = int(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Port.ValueInt32())
 				} else {
 					port = nil
 				}
-				proxyTypes1 := make([]shared.MeshTCPRouteItemSpecToProxyTypes, 0, len(backendRefsItem.ProxyTypes))
-				for _, proxyTypesItem1 := range backendRefsItem.ProxyTypes {
+				proxyTypes1 := make([]shared.MeshTCPRouteItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].ProxyTypes))
+				for _, proxyTypesItem1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].ProxyTypes {
 					proxyTypes1 = append(proxyTypes1, shared.MeshTCPRouteItemSpecToProxyTypes(proxyTypesItem1.ValueString()))
 				}
 				sectionName1 := new(string)
-				if !backendRefsItem.SectionName.IsUnknown() && !backendRefsItem.SectionName.IsNull() {
-					*sectionName1 = backendRefsItem.SectionName.ValueString()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.IsNull() {
+					*sectionName1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].SectionName.ValueString()
 				} else {
 					sectionName1 = nil
 				}
 				tags1 := make(map[string]string)
-				for tagsKey1, tagsValue1 := range backendRefsItem.Tags {
+				for tagsKey1 := range r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Tags {
 					var tagsInst1 string
-					tagsInst1 = tagsValue1.ValueString()
+					tagsInst1 = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Tags[tagsKey1].ValueString()
 
 					tags1[tagsKey1] = tagsInst1
 				}
 				weight := new(int64)
-				if !backendRefsItem.Weight.IsUnknown() && !backendRefsItem.Weight.IsNull() {
-					*weight = backendRefsItem.Weight.ValueInt64()
+				if !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.IsUnknown() && !r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.IsNull() {
+					*weight = r.Spec.To[toIndex].Rules[rulesIndex].Default.BackendRefs[backendRefsIndex].Weight.ValueInt64()
 				} else {
 					weight = nil
 				}
@@ -365,46 +365,46 @@ func (r *MeshTCPRouteResourceModel) ToSharedMeshTCPRouteItemInput(ctx context.Co
 				Default: defaultVar,
 			})
 		}
-		kind2 := shared.MeshTCPRouteItemSpecKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshTCPRouteItemSpecKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name3 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name3 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshTCPRouteItemSpecProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshTCPRouteItemSpecProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshTCPRouteItemSpecProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshtimeout_resource.go
+++ b/internal/provider/meshtimeout_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -76,9 +75,6 @@ func (r *MeshTimeoutResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -103,9 +99,6 @@ func (r *MeshTimeoutResource) Schema(ctx context.Context, req resource.SchemaReq
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -865,7 +858,10 @@ func (r *MeshTimeoutResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtimeout_resource_sdk.go
+++ b/internal/provider/meshtimeout_resource_sdk.go
@@ -278,44 +278,44 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshTimeoutItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshTimeoutItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			connectionTimeout := new(string)
-			if !fromItem.Default.ConnectionTimeout.IsUnknown() && !fromItem.Default.ConnectionTimeout.IsNull() {
-				*connectionTimeout = fromItem.Default.ConnectionTimeout.ValueString()
+			if !r.Spec.From[fromIndex].Default.ConnectionTimeout.IsUnknown() && !r.Spec.From[fromIndex].Default.ConnectionTimeout.IsNull() {
+				*connectionTimeout = r.Spec.From[fromIndex].Default.ConnectionTimeout.ValueString()
 			} else {
 				connectionTimeout = nil
 			}
 			var http *shared.MeshTimeoutItemHTTP
-			if fromItem.Default.HTTP != nil {
+			if r.Spec.From[fromIndex].Default.HTTP != nil {
 				maxConnectionDuration := new(string)
-				if !fromItem.Default.HTTP.MaxConnectionDuration.IsUnknown() && !fromItem.Default.HTTP.MaxConnectionDuration.IsNull() {
-					*maxConnectionDuration = fromItem.Default.HTTP.MaxConnectionDuration.ValueString()
+				if !r.Spec.From[fromIndex].Default.HTTP.MaxConnectionDuration.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.MaxConnectionDuration.IsNull() {
+					*maxConnectionDuration = r.Spec.From[fromIndex].Default.HTTP.MaxConnectionDuration.ValueString()
 				} else {
 					maxConnectionDuration = nil
 				}
 				maxStreamDuration := new(string)
-				if !fromItem.Default.HTTP.MaxStreamDuration.IsUnknown() && !fromItem.Default.HTTP.MaxStreamDuration.IsNull() {
-					*maxStreamDuration = fromItem.Default.HTTP.MaxStreamDuration.ValueString()
+				if !r.Spec.From[fromIndex].Default.HTTP.MaxStreamDuration.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.MaxStreamDuration.IsNull() {
+					*maxStreamDuration = r.Spec.From[fromIndex].Default.HTTP.MaxStreamDuration.ValueString()
 				} else {
 					maxStreamDuration = nil
 				}
 				requestHeadersTimeout := new(string)
-				if !fromItem.Default.HTTP.RequestHeadersTimeout.IsUnknown() && !fromItem.Default.HTTP.RequestHeadersTimeout.IsNull() {
-					*requestHeadersTimeout = fromItem.Default.HTTP.RequestHeadersTimeout.ValueString()
+				if !r.Spec.From[fromIndex].Default.HTTP.RequestHeadersTimeout.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.RequestHeadersTimeout.IsNull() {
+					*requestHeadersTimeout = r.Spec.From[fromIndex].Default.HTTP.RequestHeadersTimeout.ValueString()
 				} else {
 					requestHeadersTimeout = nil
 				}
 				requestTimeout := new(string)
-				if !fromItem.Default.HTTP.RequestTimeout.IsUnknown() && !fromItem.Default.HTTP.RequestTimeout.IsNull() {
-					*requestTimeout = fromItem.Default.HTTP.RequestTimeout.ValueString()
+				if !r.Spec.From[fromIndex].Default.HTTP.RequestTimeout.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.RequestTimeout.IsNull() {
+					*requestTimeout = r.Spec.From[fromIndex].Default.HTTP.RequestTimeout.ValueString()
 				} else {
 					requestTimeout = nil
 				}
 				streamIdleTimeout := new(string)
-				if !fromItem.Default.HTTP.StreamIdleTimeout.IsUnknown() && !fromItem.Default.HTTP.StreamIdleTimeout.IsNull() {
-					*streamIdleTimeout = fromItem.Default.HTTP.StreamIdleTimeout.ValueString()
+				if !r.Spec.From[fromIndex].Default.HTTP.StreamIdleTimeout.IsUnknown() && !r.Spec.From[fromIndex].Default.HTTP.StreamIdleTimeout.IsNull() {
+					*streamIdleTimeout = r.Spec.From[fromIndex].Default.HTTP.StreamIdleTimeout.ValueString()
 				} else {
 					streamIdleTimeout = nil
 				}
@@ -328,8 +328,8 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 				}
 			}
 			idleTimeout := new(string)
-			if !fromItem.Default.IdleTimeout.IsUnknown() && !fromItem.Default.IdleTimeout.IsNull() {
-				*idleTimeout = fromItem.Default.IdleTimeout.ValueString()
+			if !r.Spec.From[fromIndex].Default.IdleTimeout.IsUnknown() && !r.Spec.From[fromIndex].Default.IdleTimeout.IsNull() {
+				*idleTimeout = r.Spec.From[fromIndex].Default.IdleTimeout.ValueString()
 			} else {
 				idleTimeout = nil
 			}
@@ -339,46 +339,46 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 				IdleTimeout:       idleTimeout,
 			}
 		}
-		kind := shared.MeshTimeoutItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshTimeoutItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshTimeoutItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshTimeoutItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshTimeoutItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -398,44 +398,44 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 		})
 	}
 	rules := make([]shared.MeshTimeoutItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
+	for rulesIndex := range r.Spec.Rules {
 		var default1 *shared.MeshTimeoutItemSpecDefault
-		if rulesItem.Default != nil {
+		if r.Spec.Rules[rulesIndex].Default != nil {
 			connectionTimeout1 := new(string)
-			if !rulesItem.Default.ConnectionTimeout.IsUnknown() && !rulesItem.Default.ConnectionTimeout.IsNull() {
-				*connectionTimeout1 = rulesItem.Default.ConnectionTimeout.ValueString()
+			if !r.Spec.Rules[rulesIndex].Default.ConnectionTimeout.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.ConnectionTimeout.IsNull() {
+				*connectionTimeout1 = r.Spec.Rules[rulesIndex].Default.ConnectionTimeout.ValueString()
 			} else {
 				connectionTimeout1 = nil
 			}
 			var http1 *shared.MeshTimeoutItemSpecHTTP
-			if rulesItem.Default.HTTP != nil {
+			if r.Spec.Rules[rulesIndex].Default.HTTP != nil {
 				maxConnectionDuration1 := new(string)
-				if !rulesItem.Default.HTTP.MaxConnectionDuration.IsUnknown() && !rulesItem.Default.HTTP.MaxConnectionDuration.IsNull() {
-					*maxConnectionDuration1 = rulesItem.Default.HTTP.MaxConnectionDuration.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP.MaxConnectionDuration.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP.MaxConnectionDuration.IsNull() {
+					*maxConnectionDuration1 = r.Spec.Rules[rulesIndex].Default.HTTP.MaxConnectionDuration.ValueString()
 				} else {
 					maxConnectionDuration1 = nil
 				}
 				maxStreamDuration1 := new(string)
-				if !rulesItem.Default.HTTP.MaxStreamDuration.IsUnknown() && !rulesItem.Default.HTTP.MaxStreamDuration.IsNull() {
-					*maxStreamDuration1 = rulesItem.Default.HTTP.MaxStreamDuration.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP.MaxStreamDuration.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP.MaxStreamDuration.IsNull() {
+					*maxStreamDuration1 = r.Spec.Rules[rulesIndex].Default.HTTP.MaxStreamDuration.ValueString()
 				} else {
 					maxStreamDuration1 = nil
 				}
 				requestHeadersTimeout1 := new(string)
-				if !rulesItem.Default.HTTP.RequestHeadersTimeout.IsUnknown() && !rulesItem.Default.HTTP.RequestHeadersTimeout.IsNull() {
-					*requestHeadersTimeout1 = rulesItem.Default.HTTP.RequestHeadersTimeout.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP.RequestHeadersTimeout.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP.RequestHeadersTimeout.IsNull() {
+					*requestHeadersTimeout1 = r.Spec.Rules[rulesIndex].Default.HTTP.RequestHeadersTimeout.ValueString()
 				} else {
 					requestHeadersTimeout1 = nil
 				}
 				requestTimeout1 := new(string)
-				if !rulesItem.Default.HTTP.RequestTimeout.IsUnknown() && !rulesItem.Default.HTTP.RequestTimeout.IsNull() {
-					*requestTimeout1 = rulesItem.Default.HTTP.RequestTimeout.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP.RequestTimeout.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP.RequestTimeout.IsNull() {
+					*requestTimeout1 = r.Spec.Rules[rulesIndex].Default.HTTP.RequestTimeout.ValueString()
 				} else {
 					requestTimeout1 = nil
 				}
 				streamIdleTimeout1 := new(string)
-				if !rulesItem.Default.HTTP.StreamIdleTimeout.IsUnknown() && !rulesItem.Default.HTTP.StreamIdleTimeout.IsNull() {
-					*streamIdleTimeout1 = rulesItem.Default.HTTP.StreamIdleTimeout.ValueString()
+				if !r.Spec.Rules[rulesIndex].Default.HTTP.StreamIdleTimeout.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.HTTP.StreamIdleTimeout.IsNull() {
+					*streamIdleTimeout1 = r.Spec.Rules[rulesIndex].Default.HTTP.StreamIdleTimeout.ValueString()
 				} else {
 					streamIdleTimeout1 = nil
 				}
@@ -448,8 +448,8 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 				}
 			}
 			idleTimeout1 := new(string)
-			if !rulesItem.Default.IdleTimeout.IsUnknown() && !rulesItem.Default.IdleTimeout.IsNull() {
-				*idleTimeout1 = rulesItem.Default.IdleTimeout.ValueString()
+			if !r.Spec.Rules[rulesIndex].Default.IdleTimeout.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.IdleTimeout.IsNull() {
+				*idleTimeout1 = r.Spec.Rules[rulesIndex].Default.IdleTimeout.ValueString()
 			} else {
 				idleTimeout1 = nil
 			}
@@ -467,9 +467,9 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshTimeoutItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -502,9 +502,9 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}
@@ -520,44 +520,44 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 		}
 	}
 	to := make([]shared.MeshTimeoutItemTo, 0, len(r.Spec.To))
-	for _, toItem := range r.Spec.To {
+	for toIndex := range r.Spec.To {
 		var default2 *shared.MeshTimeoutItemSpecToDefault
-		if toItem.Default != nil {
+		if r.Spec.To[toIndex].Default != nil {
 			connectionTimeout2 := new(string)
-			if !toItem.Default.ConnectionTimeout.IsUnknown() && !toItem.Default.ConnectionTimeout.IsNull() {
-				*connectionTimeout2 = toItem.Default.ConnectionTimeout.ValueString()
+			if !r.Spec.To[toIndex].Default.ConnectionTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.ConnectionTimeout.IsNull() {
+				*connectionTimeout2 = r.Spec.To[toIndex].Default.ConnectionTimeout.ValueString()
 			} else {
 				connectionTimeout2 = nil
 			}
 			var http2 *shared.MeshTimeoutItemSpecToHTTP
-			if toItem.Default.HTTP != nil {
+			if r.Spec.To[toIndex].Default.HTTP != nil {
 				maxConnectionDuration2 := new(string)
-				if !toItem.Default.HTTP.MaxConnectionDuration.IsUnknown() && !toItem.Default.HTTP.MaxConnectionDuration.IsNull() {
-					*maxConnectionDuration2 = toItem.Default.HTTP.MaxConnectionDuration.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.MaxConnectionDuration.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.MaxConnectionDuration.IsNull() {
+					*maxConnectionDuration2 = r.Spec.To[toIndex].Default.HTTP.MaxConnectionDuration.ValueString()
 				} else {
 					maxConnectionDuration2 = nil
 				}
 				maxStreamDuration2 := new(string)
-				if !toItem.Default.HTTP.MaxStreamDuration.IsUnknown() && !toItem.Default.HTTP.MaxStreamDuration.IsNull() {
-					*maxStreamDuration2 = toItem.Default.HTTP.MaxStreamDuration.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.MaxStreamDuration.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.MaxStreamDuration.IsNull() {
+					*maxStreamDuration2 = r.Spec.To[toIndex].Default.HTTP.MaxStreamDuration.ValueString()
 				} else {
 					maxStreamDuration2 = nil
 				}
 				requestHeadersTimeout2 := new(string)
-				if !toItem.Default.HTTP.RequestHeadersTimeout.IsUnknown() && !toItem.Default.HTTP.RequestHeadersTimeout.IsNull() {
-					*requestHeadersTimeout2 = toItem.Default.HTTP.RequestHeadersTimeout.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.RequestHeadersTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RequestHeadersTimeout.IsNull() {
+					*requestHeadersTimeout2 = r.Spec.To[toIndex].Default.HTTP.RequestHeadersTimeout.ValueString()
 				} else {
 					requestHeadersTimeout2 = nil
 				}
 				requestTimeout2 := new(string)
-				if !toItem.Default.HTTP.RequestTimeout.IsUnknown() && !toItem.Default.HTTP.RequestTimeout.IsNull() {
-					*requestTimeout2 = toItem.Default.HTTP.RequestTimeout.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.RequestTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.RequestTimeout.IsNull() {
+					*requestTimeout2 = r.Spec.To[toIndex].Default.HTTP.RequestTimeout.ValueString()
 				} else {
 					requestTimeout2 = nil
 				}
 				streamIdleTimeout2 := new(string)
-				if !toItem.Default.HTTP.StreamIdleTimeout.IsUnknown() && !toItem.Default.HTTP.StreamIdleTimeout.IsNull() {
-					*streamIdleTimeout2 = toItem.Default.HTTP.StreamIdleTimeout.ValueString()
+				if !r.Spec.To[toIndex].Default.HTTP.StreamIdleTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.HTTP.StreamIdleTimeout.IsNull() {
+					*streamIdleTimeout2 = r.Spec.To[toIndex].Default.HTTP.StreamIdleTimeout.ValueString()
 				} else {
 					streamIdleTimeout2 = nil
 				}
@@ -570,8 +570,8 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 				}
 			}
 			idleTimeout2 := new(string)
-			if !toItem.Default.IdleTimeout.IsUnknown() && !toItem.Default.IdleTimeout.IsNull() {
-				*idleTimeout2 = toItem.Default.IdleTimeout.ValueString()
+			if !r.Spec.To[toIndex].Default.IdleTimeout.IsUnknown() && !r.Spec.To[toIndex].Default.IdleTimeout.IsNull() {
+				*idleTimeout2 = r.Spec.To[toIndex].Default.IdleTimeout.ValueString()
 			} else {
 				idleTimeout2 = nil
 			}
@@ -581,46 +581,46 @@ func (r *MeshTimeoutResourceModel) ToSharedMeshTimeoutItemInput(ctx context.Cont
 				IdleTimeout:       idleTimeout2,
 			}
 		}
-		kind2 := shared.MeshTimeoutItemSpecToKind(toItem.TargetRef.Kind.ValueString())
+		kind2 := shared.MeshTimeoutItemSpecToKind(r.Spec.To[toIndex].TargetRef.Kind.ValueString())
 		labels3 := make(map[string]string)
-		for labelsKey2, labelsValue2 := range toItem.TargetRef.Labels {
+		for labelsKey2 := range r.Spec.To[toIndex].TargetRef.Labels {
 			var labelsInst2 string
-			labelsInst2 = labelsValue2.ValueString()
+			labelsInst2 = r.Spec.To[toIndex].TargetRef.Labels[labelsKey2].ValueString()
 
 			labels3[labelsKey2] = labelsInst2
 		}
 		mesh3 := new(string)
-		if !toItem.TargetRef.Mesh.IsUnknown() && !toItem.TargetRef.Mesh.IsNull() {
-			*mesh3 = toItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Mesh.IsNull() {
+			*mesh3 = r.Spec.To[toIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh3 = nil
 		}
 		name3 := new(string)
-		if !toItem.TargetRef.Name.IsUnknown() && !toItem.TargetRef.Name.IsNull() {
-			*name3 = toItem.TargetRef.Name.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Name.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Name.IsNull() {
+			*name3 = r.Spec.To[toIndex].TargetRef.Name.ValueString()
 		} else {
 			name3 = nil
 		}
 		namespace2 := new(string)
-		if !toItem.TargetRef.Namespace.IsUnknown() && !toItem.TargetRef.Namespace.IsNull() {
-			*namespace2 = toItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.To[toIndex].TargetRef.Namespace.IsNull() {
+			*namespace2 = r.Spec.To[toIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace2 = nil
 		}
-		proxyTypes2 := make([]shared.MeshTimeoutItemSpecToProxyTypes, 0, len(toItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem2 := range toItem.TargetRef.ProxyTypes {
+		proxyTypes2 := make([]shared.MeshTimeoutItemSpecToProxyTypes, 0, len(r.Spec.To[toIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem2 := range r.Spec.To[toIndex].TargetRef.ProxyTypes {
 			proxyTypes2 = append(proxyTypes2, shared.MeshTimeoutItemSpecToProxyTypes(proxyTypesItem2.ValueString()))
 		}
 		sectionName2 := new(string)
-		if !toItem.TargetRef.SectionName.IsUnknown() && !toItem.TargetRef.SectionName.IsNull() {
-			*sectionName2 = toItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.To[toIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.To[toIndex].TargetRef.SectionName.IsNull() {
+			*sectionName2 = r.Spec.To[toIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName2 = nil
 		}
 		tags2 := make(map[string]string)
-		for tagsKey2, tagsValue2 := range toItem.TargetRef.Tags {
+		for tagsKey2 := range r.Spec.To[toIndex].TargetRef.Tags {
 			var tagsInst2 string
-			tagsInst2 = tagsValue2.ValueString()
+			tagsInst2 = r.Spec.To[toIndex].TargetRef.Tags[tagsKey2].ValueString()
 
 			tags2[tagsKey2] = tagsInst2
 		}

--- a/internal/provider/meshtls_resource.go
+++ b/internal/provider/meshtls_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -77,9 +76,6 @@ func (r *MeshTLSResource) Schema(ctx context.Context, req resource.SchemaRequest
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +100,6 @@ func (r *MeshTLSResource) Schema(ctx context.Context, req resource.SchemaRequest
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -741,7 +734,10 @@ func (r *MeshTLSResource) Delete(ctx context.Context, req resource.DeleteRequest
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtls_resource_sdk.go
+++ b/internal/provider/meshtls_resource_sdk.go
@@ -256,30 +256,30 @@ func (r *MeshTLSResourceModel) ToSharedMeshTLSItemInput(ctx context.Context) (*s
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshTLSItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshTLSItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			mode := new(shared.MeshTLSItemMode)
-			if !fromItem.Default.Mode.IsUnknown() && !fromItem.Default.Mode.IsNull() {
-				*mode = shared.MeshTLSItemMode(fromItem.Default.Mode.ValueString())
+			if !r.Spec.From[fromIndex].Default.Mode.IsUnknown() && !r.Spec.From[fromIndex].Default.Mode.IsNull() {
+				*mode = shared.MeshTLSItemMode(r.Spec.From[fromIndex].Default.Mode.ValueString())
 			} else {
 				mode = nil
 			}
-			tlsCiphers := make([]shared.TLSCiphers, 0, len(fromItem.Default.TLSCiphers))
-			for _, tlsCiphersItem := range fromItem.Default.TLSCiphers {
+			tlsCiphers := make([]shared.TLSCiphers, 0, len(r.Spec.From[fromIndex].Default.TLSCiphers))
+			for _, tlsCiphersItem := range r.Spec.From[fromIndex].Default.TLSCiphers {
 				tlsCiphers = append(tlsCiphers, shared.TLSCiphers(tlsCiphersItem.ValueString()))
 			}
 			var tlsVersion *shared.TLSVersion
-			if fromItem.Default.TLSVersion != nil {
+			if r.Spec.From[fromIndex].Default.TLSVersion != nil {
 				max := new(shared.MeshTLSItemSpecMax)
-				if !fromItem.Default.TLSVersion.Max.IsUnknown() && !fromItem.Default.TLSVersion.Max.IsNull() {
-					*max = shared.MeshTLSItemSpecMax(fromItem.Default.TLSVersion.Max.ValueString())
+				if !r.Spec.From[fromIndex].Default.TLSVersion.Max.IsUnknown() && !r.Spec.From[fromIndex].Default.TLSVersion.Max.IsNull() {
+					*max = shared.MeshTLSItemSpecMax(r.Spec.From[fromIndex].Default.TLSVersion.Max.ValueString())
 				} else {
 					max = nil
 				}
 				min := new(shared.MeshTLSItemSpecMin)
-				if !fromItem.Default.TLSVersion.Min.IsUnknown() && !fromItem.Default.TLSVersion.Min.IsNull() {
-					*min = shared.MeshTLSItemSpecMin(fromItem.Default.TLSVersion.Min.ValueString())
+				if !r.Spec.From[fromIndex].Default.TLSVersion.Min.IsUnknown() && !r.Spec.From[fromIndex].Default.TLSVersion.Min.IsNull() {
+					*min = shared.MeshTLSItemSpecMin(r.Spec.From[fromIndex].Default.TLSVersion.Min.ValueString())
 				} else {
 					min = nil
 				}
@@ -294,46 +294,46 @@ func (r *MeshTLSResourceModel) ToSharedMeshTLSItemInput(ctx context.Context) (*s
 				TLSVersion: tlsVersion,
 			}
 		}
-		kind := shared.MeshTLSItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshTLSItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshTLSItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshTLSItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshTLSItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -353,30 +353,30 @@ func (r *MeshTLSResourceModel) ToSharedMeshTLSItemInput(ctx context.Context) (*s
 		})
 	}
 	rules := make([]shared.MeshTLSItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
+	for rulesIndex := range r.Spec.Rules {
 		var default1 *shared.MeshTLSItemSpecDefault
-		if rulesItem.Default != nil {
+		if r.Spec.Rules[rulesIndex].Default != nil {
 			mode1 := new(shared.MeshTLSItemSpecMode)
-			if !rulesItem.Default.Mode.IsUnknown() && !rulesItem.Default.Mode.IsNull() {
-				*mode1 = shared.MeshTLSItemSpecMode(rulesItem.Default.Mode.ValueString())
+			if !r.Spec.Rules[rulesIndex].Default.Mode.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.Mode.IsNull() {
+				*mode1 = shared.MeshTLSItemSpecMode(r.Spec.Rules[rulesIndex].Default.Mode.ValueString())
 			} else {
 				mode1 = nil
 			}
-			tlsCiphers1 := make([]shared.MeshTLSItemTLSCiphers, 0, len(rulesItem.Default.TLSCiphers))
-			for _, tlsCiphersItem1 := range rulesItem.Default.TLSCiphers {
+			tlsCiphers1 := make([]shared.MeshTLSItemTLSCiphers, 0, len(r.Spec.Rules[rulesIndex].Default.TLSCiphers))
+			for _, tlsCiphersItem1 := range r.Spec.Rules[rulesIndex].Default.TLSCiphers {
 				tlsCiphers1 = append(tlsCiphers1, shared.MeshTLSItemTLSCiphers(tlsCiphersItem1.ValueString()))
 			}
 			var tlsVersion1 *shared.MeshTLSItemTLSVersion
-			if rulesItem.Default.TLSVersion != nil {
+			if r.Spec.Rules[rulesIndex].Default.TLSVersion != nil {
 				max1 := new(shared.MeshTLSItemMax)
-				if !rulesItem.Default.TLSVersion.Max.IsUnknown() && !rulesItem.Default.TLSVersion.Max.IsNull() {
-					*max1 = shared.MeshTLSItemMax(rulesItem.Default.TLSVersion.Max.ValueString())
+				if !r.Spec.Rules[rulesIndex].Default.TLSVersion.Max.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.TLSVersion.Max.IsNull() {
+					*max1 = shared.MeshTLSItemMax(r.Spec.Rules[rulesIndex].Default.TLSVersion.Max.ValueString())
 				} else {
 					max1 = nil
 				}
 				min1 := new(shared.MeshTLSItemMin)
-				if !rulesItem.Default.TLSVersion.Min.IsUnknown() && !rulesItem.Default.TLSVersion.Min.IsNull() {
-					*min1 = shared.MeshTLSItemMin(rulesItem.Default.TLSVersion.Min.ValueString())
+				if !r.Spec.Rules[rulesIndex].Default.TLSVersion.Min.IsUnknown() && !r.Spec.Rules[rulesIndex].Default.TLSVersion.Min.IsNull() {
+					*min1 = shared.MeshTLSItemMin(r.Spec.Rules[rulesIndex].Default.TLSVersion.Min.ValueString())
 				} else {
 					min1 = nil
 				}
@@ -399,9 +399,9 @@ func (r *MeshTLSResourceModel) ToSharedMeshTLSItemInput(ctx context.Context) (*s
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshTLSItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -434,9 +434,9 @@ func (r *MeshTLSResourceModel) ToSharedMeshTLSItemInput(ctx context.Context) (*s
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}

--- a/internal/provider/meshtrace_resource.go
+++ b/internal/provider/meshtrace_resource.go
@@ -26,7 +26,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -80,9 +79,6 @@ func (r *MeshTraceResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -107,9 +103,6 @@ func (r *MeshTraceResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -782,7 +775,10 @@ func (r *MeshTraceResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtrace_resource_sdk.go
+++ b/internal/provider/meshtrace_resource_sdk.go
@@ -252,17 +252,17 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 	var defaultVar *shared.MeshTraceItemDefault
 	if r.Spec.Default != nil {
 		backends := make([]shared.MeshTraceItemBackends, 0, len(r.Spec.Default.Backends))
-		for _, backendsItem := range r.Spec.Default.Backends {
+		for backendsIndex := range r.Spec.Default.Backends {
 			var datadog *shared.Datadog
-			if backendsItem.Datadog != nil {
+			if r.Spec.Default.Backends[backendsIndex].Datadog != nil {
 				splitService := new(bool)
-				if !backendsItem.Datadog.SplitService.IsUnknown() && !backendsItem.Datadog.SplitService.IsNull() {
-					*splitService = backendsItem.Datadog.SplitService.ValueBool()
+				if !r.Spec.Default.Backends[backendsIndex].Datadog.SplitService.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Datadog.SplitService.IsNull() {
+					*splitService = r.Spec.Default.Backends[backendsIndex].Datadog.SplitService.ValueBool()
 				} else {
 					splitService = nil
 				}
 				var url string
-				url = backendsItem.Datadog.URL.ValueString()
+				url = r.Spec.Default.Backends[backendsIndex].Datadog.URL.ValueString()
 
 				datadog = &shared.Datadog{
 					SplitService: splitService,
@@ -270,37 +270,37 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 				}
 			}
 			var openTelemetry *shared.MeshTraceItemOpenTelemetry
-			if backendsItem.OpenTelemetry != nil {
+			if r.Spec.Default.Backends[backendsIndex].OpenTelemetry != nil {
 				var endpoint string
-				endpoint = backendsItem.OpenTelemetry.Endpoint.ValueString()
+				endpoint = r.Spec.Default.Backends[backendsIndex].OpenTelemetry.Endpoint.ValueString()
 
 				openTelemetry = &shared.MeshTraceItemOpenTelemetry{
 					Endpoint: endpoint,
 				}
 			}
-			type1 := shared.MeshTraceItemSpecType(backendsItem.Type.ValueString())
+			type1 := shared.MeshTraceItemSpecType(r.Spec.Default.Backends[backendsIndex].Type.ValueString())
 			var zipkin *shared.Zipkin
-			if backendsItem.Zipkin != nil {
+			if r.Spec.Default.Backends[backendsIndex].Zipkin != nil {
 				apiVersion := new(shared.MeshTraceItemAPIVersion)
-				if !backendsItem.Zipkin.APIVersion.IsUnknown() && !backendsItem.Zipkin.APIVersion.IsNull() {
-					*apiVersion = shared.MeshTraceItemAPIVersion(backendsItem.Zipkin.APIVersion.ValueString())
+				if !r.Spec.Default.Backends[backendsIndex].Zipkin.APIVersion.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Zipkin.APIVersion.IsNull() {
+					*apiVersion = shared.MeshTraceItemAPIVersion(r.Spec.Default.Backends[backendsIndex].Zipkin.APIVersion.ValueString())
 				} else {
 					apiVersion = nil
 				}
 				sharedSpanContext := new(bool)
-				if !backendsItem.Zipkin.SharedSpanContext.IsUnknown() && !backendsItem.Zipkin.SharedSpanContext.IsNull() {
-					*sharedSpanContext = backendsItem.Zipkin.SharedSpanContext.ValueBool()
+				if !r.Spec.Default.Backends[backendsIndex].Zipkin.SharedSpanContext.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Zipkin.SharedSpanContext.IsNull() {
+					*sharedSpanContext = r.Spec.Default.Backends[backendsIndex].Zipkin.SharedSpanContext.ValueBool()
 				} else {
 					sharedSpanContext = nil
 				}
 				traceId128bit := new(bool)
-				if !backendsItem.Zipkin.TraceId128bit.IsUnknown() && !backendsItem.Zipkin.TraceId128bit.IsNull() {
-					*traceId128bit = backendsItem.Zipkin.TraceId128bit.ValueBool()
+				if !r.Spec.Default.Backends[backendsIndex].Zipkin.TraceId128bit.IsUnknown() && !r.Spec.Default.Backends[backendsIndex].Zipkin.TraceId128bit.IsNull() {
+					*traceId128bit = r.Spec.Default.Backends[backendsIndex].Zipkin.TraceId128bit.ValueBool()
 				} else {
 					traceId128bit = nil
 				}
 				var url1 string
-				url1 = backendsItem.Zipkin.URL.ValueString()
+				url1 = r.Spec.Default.Backends[backendsIndex].Zipkin.URL.ValueString()
 
 				zipkin = &shared.Zipkin{
 					APIVersion:        apiVersion,
@@ -400,17 +400,17 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 			}
 		}
 		tags := make([]shared.Tags, 0, len(r.Spec.Default.Tags))
-		for _, tagsItem := range r.Spec.Default.Tags {
+		for tagsIndex := range r.Spec.Default.Tags {
 			var header *shared.Header
-			if tagsItem.Header != nil {
+			if r.Spec.Default.Tags[tagsIndex].Header != nil {
 				defaultVar1 := new(string)
-				if !tagsItem.Header.Default.IsUnknown() && !tagsItem.Header.Default.IsNull() {
-					*defaultVar1 = tagsItem.Header.Default.ValueString()
+				if !r.Spec.Default.Tags[tagsIndex].Header.Default.IsUnknown() && !r.Spec.Default.Tags[tagsIndex].Header.Default.IsNull() {
+					*defaultVar1 = r.Spec.Default.Tags[tagsIndex].Header.Default.ValueString()
 				} else {
 					defaultVar1 = nil
 				}
 				var name1 string
-				name1 = tagsItem.Header.Name.ValueString()
+				name1 = r.Spec.Default.Tags[tagsIndex].Header.Name.ValueString()
 
 				header = &shared.Header{
 					Default: defaultVar1,
@@ -418,13 +418,13 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 				}
 			}
 			literal := new(string)
-			if !tagsItem.Literal.IsUnknown() && !tagsItem.Literal.IsNull() {
-				*literal = tagsItem.Literal.ValueString()
+			if !r.Spec.Default.Tags[tagsIndex].Literal.IsUnknown() && !r.Spec.Default.Tags[tagsIndex].Literal.IsNull() {
+				*literal = r.Spec.Default.Tags[tagsIndex].Literal.ValueString()
 			} else {
 				literal = nil
 			}
 			var name2 string
-			name2 = tagsItem.Name.ValueString()
+			name2 = r.Spec.Default.Tags[tagsIndex].Name.ValueString()
 
 			tags = append(tags, shared.Tags{
 				Header:  header,
@@ -442,9 +442,9 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 	if r.Spec.TargetRef != nil {
 		kind := shared.MeshTraceItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range r.Spec.TargetRef.Labels {
+		for labelsKey := range r.Spec.TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
@@ -477,9 +477,9 @@ func (r *MeshTraceResourceModel) ToSharedMeshTraceItemInput(ctx context.Context)
 			sectionName = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey, tagsValue := range r.Spec.TargetRef.Tags {
+		for tagsKey := range r.Spec.TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.TargetRef.Tags[tagsKey].ValueString()
 
 			tags1[tagsKey] = tagsInst
 		}

--- a/internal/provider/meshtrafficpermission_resource.go
+++ b/internal/provider/meshtrafficpermission_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -76,9 +75,6 @@ func (r *MeshTrafficPermissionResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -103,9 +99,6 @@ func (r *MeshTrafficPermissionResource) Schema(ctx context.Context, req resource
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -763,7 +756,10 @@ func (r *MeshTrafficPermissionResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtrafficpermission_resource_sdk.go
+++ b/internal/provider/meshtrafficpermission_resource_sdk.go
@@ -253,12 +253,12 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	from := make([]shared.MeshTrafficPermissionItemFrom, 0, len(r.Spec.From))
-	for _, fromItem := range r.Spec.From {
+	for fromIndex := range r.Spec.From {
 		var defaultVar *shared.MeshTrafficPermissionItemDefault
-		if fromItem.Default != nil {
+		if r.Spec.From[fromIndex].Default != nil {
 			action := new(shared.MeshTrafficPermissionItemAction)
-			if !fromItem.Default.Action.IsUnknown() && !fromItem.Default.Action.IsNull() {
-				*action = shared.MeshTrafficPermissionItemAction(fromItem.Default.Action.ValueString())
+			if !r.Spec.From[fromIndex].Default.Action.IsUnknown() && !r.Spec.From[fromIndex].Default.Action.IsNull() {
+				*action = shared.MeshTrafficPermissionItemAction(r.Spec.From[fromIndex].Default.Action.ValueString())
 			} else {
 				action = nil
 			}
@@ -266,46 +266,46 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 				Action: action,
 			}
 		}
-		kind := shared.MeshTrafficPermissionItemSpecKind(fromItem.TargetRef.Kind.ValueString())
+		kind := shared.MeshTrafficPermissionItemSpecKind(r.Spec.From[fromIndex].TargetRef.Kind.ValueString())
 		labels1 := make(map[string]string)
-		for labelsKey, labelsValue := range fromItem.TargetRef.Labels {
+		for labelsKey := range r.Spec.From[fromIndex].TargetRef.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Spec.From[fromIndex].TargetRef.Labels[labelsKey].ValueString()
 
 			labels1[labelsKey] = labelsInst
 		}
 		mesh1 := new(string)
-		if !fromItem.TargetRef.Mesh.IsUnknown() && !fromItem.TargetRef.Mesh.IsNull() {
-			*mesh1 = fromItem.TargetRef.Mesh.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Mesh.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Mesh.IsNull() {
+			*mesh1 = r.Spec.From[fromIndex].TargetRef.Mesh.ValueString()
 		} else {
 			mesh1 = nil
 		}
 		name1 := new(string)
-		if !fromItem.TargetRef.Name.IsUnknown() && !fromItem.TargetRef.Name.IsNull() {
-			*name1 = fromItem.TargetRef.Name.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Name.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Name.IsNull() {
+			*name1 = r.Spec.From[fromIndex].TargetRef.Name.ValueString()
 		} else {
 			name1 = nil
 		}
 		namespace := new(string)
-		if !fromItem.TargetRef.Namespace.IsUnknown() && !fromItem.TargetRef.Namespace.IsNull() {
-			*namespace = fromItem.TargetRef.Namespace.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.Namespace.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.Namespace.IsNull() {
+			*namespace = r.Spec.From[fromIndex].TargetRef.Namespace.ValueString()
 		} else {
 			namespace = nil
 		}
-		proxyTypes := make([]shared.MeshTrafficPermissionItemSpecProxyTypes, 0, len(fromItem.TargetRef.ProxyTypes))
-		for _, proxyTypesItem := range fromItem.TargetRef.ProxyTypes {
+		proxyTypes := make([]shared.MeshTrafficPermissionItemSpecProxyTypes, 0, len(r.Spec.From[fromIndex].TargetRef.ProxyTypes))
+		for _, proxyTypesItem := range r.Spec.From[fromIndex].TargetRef.ProxyTypes {
 			proxyTypes = append(proxyTypes, shared.MeshTrafficPermissionItemSpecProxyTypes(proxyTypesItem.ValueString()))
 		}
 		sectionName := new(string)
-		if !fromItem.TargetRef.SectionName.IsUnknown() && !fromItem.TargetRef.SectionName.IsNull() {
-			*sectionName = fromItem.TargetRef.SectionName.ValueString()
+		if !r.Spec.From[fromIndex].TargetRef.SectionName.IsUnknown() && !r.Spec.From[fromIndex].TargetRef.SectionName.IsNull() {
+			*sectionName = r.Spec.From[fromIndex].TargetRef.SectionName.ValueString()
 		} else {
 			sectionName = nil
 		}
 		tags := make(map[string]string)
-		for tagsKey, tagsValue := range fromItem.TargetRef.Tags {
+		for tagsKey := range r.Spec.From[fromIndex].TargetRef.Tags {
 			var tagsInst string
-			tagsInst = tagsValue.ValueString()
+			tagsInst = r.Spec.From[fromIndex].TargetRef.Tags[tagsKey].ValueString()
 
 			tags[tagsKey] = tagsInst
 		}
@@ -325,14 +325,14 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 		})
 	}
 	rules := make([]shared.MeshTrafficPermissionItemRules, 0, len(r.Spec.Rules))
-	for _, rulesItem := range r.Spec.Rules {
-		allow := make([]shared.Allow, 0, len(rulesItem.Default.Allow))
-		for _, allowItem := range rulesItem.Default.Allow {
+	for rulesIndex := range r.Spec.Rules {
+		allow := make([]shared.Allow, 0, len(r.Spec.Rules[rulesIndex].Default.Allow))
+		for allowIndex := range r.Spec.Rules[rulesIndex].Default.Allow {
 			var spiffeID *shared.MeshTrafficPermissionItemSpiffeID
-			if allowItem.SpiffeID != nil {
-				typeVar1 := shared.MeshTrafficPermissionItemSpecType(allowItem.SpiffeID.Type.ValueString())
+			if r.Spec.Rules[rulesIndex].Default.Allow[allowIndex].SpiffeID != nil {
+				typeVar1 := shared.MeshTrafficPermissionItemSpecType(r.Spec.Rules[rulesIndex].Default.Allow[allowIndex].SpiffeID.Type.ValueString())
 				var value string
-				value = allowItem.SpiffeID.Value.ValueString()
+				value = r.Spec.Rules[rulesIndex].Default.Allow[allowIndex].SpiffeID.Value.ValueString()
 
 				spiffeID = &shared.MeshTrafficPermissionItemSpiffeID{
 					Type:  typeVar1,
@@ -343,13 +343,13 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 				SpiffeID: spiffeID,
 			})
 		}
-		allowWithShadowDeny := make([]shared.AllowWithShadowDeny, 0, len(rulesItem.Default.AllowWithShadowDeny))
-		for _, allowWithShadowDenyItem := range rulesItem.Default.AllowWithShadowDeny {
+		allowWithShadowDeny := make([]shared.AllowWithShadowDeny, 0, len(r.Spec.Rules[rulesIndex].Default.AllowWithShadowDeny))
+		for allowWithShadowDenyIndex := range r.Spec.Rules[rulesIndex].Default.AllowWithShadowDeny {
 			var spiffeId1 *shared.MeshTrafficPermissionItemSpecSpiffeID
-			if allowWithShadowDenyItem.SpiffeID != nil {
-				typeVar2 := shared.MeshTrafficPermissionItemSpecRulesType(allowWithShadowDenyItem.SpiffeID.Type.ValueString())
+			if r.Spec.Rules[rulesIndex].Default.AllowWithShadowDeny[allowWithShadowDenyIndex].SpiffeID != nil {
+				typeVar2 := shared.MeshTrafficPermissionItemSpecRulesType(r.Spec.Rules[rulesIndex].Default.AllowWithShadowDeny[allowWithShadowDenyIndex].SpiffeID.Type.ValueString())
 				var value1 string
-				value1 = allowWithShadowDenyItem.SpiffeID.Value.ValueString()
+				value1 = r.Spec.Rules[rulesIndex].Default.AllowWithShadowDeny[allowWithShadowDenyIndex].SpiffeID.Value.ValueString()
 
 				spiffeId1 = &shared.MeshTrafficPermissionItemSpecSpiffeID{
 					Type:  typeVar2,
@@ -360,13 +360,13 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 				SpiffeID: spiffeId1,
 			})
 		}
-		deny := make([]shared.Deny, 0, len(rulesItem.Default.Deny))
-		for _, denyItem := range rulesItem.Default.Deny {
+		deny := make([]shared.Deny, 0, len(r.Spec.Rules[rulesIndex].Default.Deny))
+		for denyIndex := range r.Spec.Rules[rulesIndex].Default.Deny {
 			var spiffeId2 *shared.MeshTrafficPermissionItemSpecRulesSpiffeID
-			if denyItem.SpiffeID != nil {
-				typeVar3 := shared.MeshTrafficPermissionItemSpecRulesDefaultType(denyItem.SpiffeID.Type.ValueString())
+			if r.Spec.Rules[rulesIndex].Default.Deny[denyIndex].SpiffeID != nil {
+				typeVar3 := shared.MeshTrafficPermissionItemSpecRulesDefaultType(r.Spec.Rules[rulesIndex].Default.Deny[denyIndex].SpiffeID.Type.ValueString())
 				var value2 string
-				value2 = denyItem.SpiffeID.Value.ValueString()
+				value2 = r.Spec.Rules[rulesIndex].Default.Deny[denyIndex].SpiffeID.Value.ValueString()
 
 				spiffeId2 = &shared.MeshTrafficPermissionItemSpecRulesSpiffeID{
 					Type:  typeVar3,
@@ -390,9 +390,9 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 	if r.Spec.TargetRef != nil {
 		kind1 := shared.MeshTrafficPermissionItemKind(r.Spec.TargetRef.Kind.ValueString())
 		labels2 := make(map[string]string)
-		for labelsKey1, labelsValue1 := range r.Spec.TargetRef.Labels {
+		for labelsKey1 := range r.Spec.TargetRef.Labels {
 			var labelsInst1 string
-			labelsInst1 = labelsValue1.ValueString()
+			labelsInst1 = r.Spec.TargetRef.Labels[labelsKey1].ValueString()
 
 			labels2[labelsKey1] = labelsInst1
 		}
@@ -425,9 +425,9 @@ func (r *MeshTrafficPermissionResourceModel) ToSharedMeshTrafficPermissionItemIn
 			sectionName1 = nil
 		}
 		tags1 := make(map[string]string)
-		for tagsKey1, tagsValue1 := range r.Spec.TargetRef.Tags {
+		for tagsKey1 := range r.Spec.TargetRef.Tags {
 			var tagsInst1 string
-			tagsInst1 = tagsValue1.ValueString()
+			tagsInst1 = r.Spec.TargetRef.Tags[tagsKey1].ValueString()
 
 			tags1[tagsKey1] = tagsInst1
 		}

--- a/internal/provider/meshtrust_resource.go
+++ b/internal/provider/meshtrust_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect-beta/internal/validators/stringvalidators"
 )
@@ -77,9 +76,6 @@ func (r *MeshTrustResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was created`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"kri": schema.StringAttribute{
 				Computed:    true,
@@ -104,9 +100,6 @@ func (r *MeshTrustResource) Schema(ctx context.Context, req resource.SchemaReque
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Time at which the resource was updated`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required: true,
@@ -509,7 +502,10 @@ func (r *MeshTrustResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshtrust_resource_sdk.go
+++ b/internal/provider/meshtrust_resource_sdk.go
@@ -157,17 +157,17 @@ func (r *MeshTrustResourceModel) ToSharedMeshTrustItemInput(ctx context.Context)
 		diags.Append(r.Labels.ElementsAs(ctx, &labels, true)...)
 	}
 	caBundles := make([]shared.CaBundles, 0, len(r.Spec.CaBundles))
-	for _, caBundlesItem := range r.Spec.CaBundles {
+	for caBundlesIndex := range r.Spec.CaBundles {
 		var pem *shared.Pem
-		if caBundlesItem.Pem != nil {
+		if r.Spec.CaBundles[caBundlesIndex].Pem != nil {
 			var value string
-			value = caBundlesItem.Pem.Value.ValueString()
+			value = r.Spec.CaBundles[caBundlesIndex].Pem.Value.ValueString()
 
 			pem = &shared.Pem{
 				Value: value,
 			}
 		}
-		type1 := shared.MeshTrustItemSpecType(caBundlesItem.Type.ValueString())
+		type1 := shared.MeshTrustItemSpecType(r.Spec.CaBundles[caBundlesIndex].Type.ValueString())
 		caBundles = append(caBundles, shared.CaBundles{
 			Pem:  pem,
 			Type: type1,

--- a/internal/provider/meshzoneegress_resource.go
+++ b/internal/provider/meshzoneegress_resource.go
@@ -422,7 +422,10 @@ func (r *MeshZoneEgressResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshzoneegress_resource_sdk.go
+++ b/internal/provider/meshzoneegress_resource_sdk.go
@@ -118,9 +118,9 @@ func (r *MeshZoneEgressResourceModel) ToSharedZoneEgressItem(ctx context.Context
 	var diags diag.Diagnostics
 
 	labels := make(map[string]string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		var labelsInst string
-		labelsInst = labelsValue.ValueString()
+		labelsInst = r.Labels[labelsKey].ValueString()
 
 		labels[labelsKey] = labelsInst
 	}

--- a/internal/provider/meshzoneingress_resource.go
+++ b/internal/provider/meshzoneingress_resource.go
@@ -469,7 +469,10 @@ func (r *MeshZoneIngressResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshzoneingress_resource_sdk.go
+++ b/internal/provider/meshzoneingress_resource_sdk.go
@@ -141,29 +141,29 @@ func (r *MeshZoneIngressResourceModel) ToSharedZoneIngressItem(ctx context.Conte
 	var availableServices []shared.AvailableServices
 	if r.AvailableServices != nil {
 		availableServices = make([]shared.AvailableServices, 0, len(r.AvailableServices))
-		for _, availableServicesItem := range r.AvailableServices {
+		for availableServicesIndex := range r.AvailableServices {
 			externalService := new(bool)
-			if !availableServicesItem.ExternalService.IsUnknown() && !availableServicesItem.ExternalService.IsNull() {
-				*externalService = availableServicesItem.ExternalService.ValueBool()
+			if !r.AvailableServices[availableServicesIndex].ExternalService.IsUnknown() && !r.AvailableServices[availableServicesIndex].ExternalService.IsNull() {
+				*externalService = r.AvailableServices[availableServicesIndex].ExternalService.ValueBool()
 			} else {
 				externalService = nil
 			}
 			instances := new(int64)
-			if !availableServicesItem.Instances.IsUnknown() && !availableServicesItem.Instances.IsNull() {
-				*instances = availableServicesItem.Instances.ValueInt64()
+			if !r.AvailableServices[availableServicesIndex].Instances.IsUnknown() && !r.AvailableServices[availableServicesIndex].Instances.IsNull() {
+				*instances = r.AvailableServices[availableServicesIndex].Instances.ValueInt64()
 			} else {
 				instances = nil
 			}
 			mesh := new(string)
-			if !availableServicesItem.Mesh.IsUnknown() && !availableServicesItem.Mesh.IsNull() {
-				*mesh = availableServicesItem.Mesh.ValueString()
+			if !r.AvailableServices[availableServicesIndex].Mesh.IsUnknown() && !r.AvailableServices[availableServicesIndex].Mesh.IsNull() {
+				*mesh = r.AvailableServices[availableServicesIndex].Mesh.ValueString()
 			} else {
 				mesh = nil
 			}
 			tags := make(map[string]string)
-			for tagsKey, tagsValue := range availableServicesItem.Tags {
+			for tagsKey := range r.AvailableServices[availableServicesIndex].Tags {
 				var tagsInst string
-				tagsInst = tagsValue.ValueString()
+				tagsInst = r.AvailableServices[availableServicesIndex].Tags[tagsKey].ValueString()
 
 				tags[tagsKey] = tagsInst
 			}
@@ -176,9 +176,9 @@ func (r *MeshZoneIngressResourceModel) ToSharedZoneIngressItem(ctx context.Conte
 		}
 	}
 	labels := make(map[string]string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		var labelsInst string
-		labelsInst = labelsValue.ValueString()
+		labelsInst = r.Labels[labelsKey].ValueString()
 
 		labels[labelsKey] = labelsInst
 	}

--- a/internal/provider/portal_resource.go
+++ b/internal/provider/portal_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -94,9 +93,6 @@ func (r *PortalResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"default_api_visibility": schema.StringAttribute{
 				Computed:    true,
@@ -197,9 +193,6 @@ func (r *PortalResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -435,7 +428,10 @@ func (r *PortalResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portal_resource_sdk.go
+++ b/internal/provider/portal_resource_sdk.go
@@ -158,10 +158,10 @@ func (r *PortalResourceModel) ToSharedCreatePortal(ctx context.Context) (*shared
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -251,10 +251,10 @@ func (r *PortalResourceModel) ToSharedUpdatePortal(ctx context.Context) (*shared
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/portalauth_resource_sdk.go
+++ b/internal/provider/portalauth_resource_sdk.go
@@ -139,8 +139,8 @@ func (r *PortalAuthResourceModel) ToSharedPortalAuthenticationSettingsUpdateRequ
 	var oidcScopes []string
 	if r.OidcScopes != nil {
 		oidcScopes = make([]string, 0, len(r.OidcScopes))
-		for _, oidcScopesItem := range r.OidcScopes {
-			oidcScopes = append(oidcScopes, oidcScopesItem.ValueString())
+		for oidcScopesIndex := range r.OidcScopes {
+			oidcScopes = append(oidcScopes, r.OidcScopes[oidcScopesIndex].ValueString())
 		}
 	}
 	var oidcClaimMappings *shared.PortalClaimMappings

--- a/internal/provider/portalcustomdomain_resource.go
+++ b/internal/provider/portalcustomdomain_resource.go
@@ -19,7 +19,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect-beta/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -60,13 +59,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Description: `must be one of ["verified", "pending"]`,
-				Validators: []validator.String{
-					stringvalidator.OneOf(
-						"verified",
-						"pending",
-					),
-				},
 			},
 			"created_at": schema.StringAttribute{
 				Computed: true,
@@ -74,9 +66,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"enabled": schema.BoolAttribute{
 				Required: true,
@@ -125,9 +114,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of the ssl certificate expiration date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"skip_ca_check": schema.BoolAttribute{
 						Computed: true,
@@ -143,9 +129,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of the ssl certificate upload date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"validation_errors": schema.ListAttribute{
 						Computed: true,
@@ -159,14 +142,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 						PlanModifiers: []planmodifier.String{
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
-						Description: `must be one of ["verified", "pending", "error"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"verified",
-								"pending",
-								"error",
-							),
-						},
 					},
 				},
 			},
@@ -176,9 +151,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -488,7 +460,10 @@ func (r *PortalCustomDomainResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalcustomization_resource_sdk.go
+++ b/internal/provider/portalcustomization_resource_sdk.go
@@ -212,8 +212,8 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var scripts []string
 		if r.Js.Scripts != nil {
 			scripts = make([]string, 0, len(r.Js.Scripts))
-			for _, scriptsItem := range r.Js.Scripts {
-				scripts = append(scripts, scriptsItem.ValueString())
+			for scriptsIndex := range r.Js.Scripts {
+				scripts = append(scripts, r.Js.Scripts[scriptsIndex].ValueString())
 			}
 		}
 		js = &shared.Js{
@@ -226,16 +226,16 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var main []shared.PortalMenuItem
 		if r.Menu.Main != nil {
 			main = make([]shared.PortalMenuItem, 0, len(r.Menu.Main))
-			for _, mainItem := range r.Menu.Main {
+			for mainIndex := range r.Menu.Main {
 				var path string
-				path = mainItem.Path.ValueString()
+				path = r.Menu.Main[mainIndex].Path.ValueString()
 
 				var title string
-				title = mainItem.Title.ValueString()
+				title = r.Menu.Main[mainIndex].Title.ValueString()
 
-				visibility := shared.Visibility(mainItem.Visibility.ValueString())
+				visibility := shared.Visibility(r.Menu.Main[mainIndex].Visibility.ValueString())
 				var external bool
-				external = mainItem.External.ValueBool()
+				external = r.Menu.Main[mainIndex].External.ValueBool()
 
 				main = append(main, shared.PortalMenuItem{
 					Path:       path,
@@ -248,21 +248,21 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var footerSections []shared.PortalFooterMenuSection
 		if r.Menu.FooterSections != nil {
 			footerSections = make([]shared.PortalFooterMenuSection, 0, len(r.Menu.FooterSections))
-			for _, footerSectionsItem := range r.Menu.FooterSections {
+			for footerSectionsIndex := range r.Menu.FooterSections {
 				var title1 string
-				title1 = footerSectionsItem.Title.ValueString()
+				title1 = r.Menu.FooterSections[footerSectionsIndex].Title.ValueString()
 
-				items := make([]shared.PortalMenuItem, 0, len(footerSectionsItem.Items))
-				for _, itemsItem := range footerSectionsItem.Items {
+				items := make([]shared.PortalMenuItem, 0, len(r.Menu.FooterSections[footerSectionsIndex].Items))
+				for itemsIndex := range r.Menu.FooterSections[footerSectionsIndex].Items {
 					var path1 string
-					path1 = itemsItem.Path.ValueString()
+					path1 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Path.ValueString()
 
 					var title2 string
-					title2 = itemsItem.Title.ValueString()
+					title2 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Title.ValueString()
 
-					visibility1 := shared.Visibility(itemsItem.Visibility.ValueString())
+					visibility1 := shared.Visibility(r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Visibility.ValueString())
 					var external1 bool
-					external1 = itemsItem.External.ValueBool()
+					external1 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].External.ValueBool()
 
 					items = append(items, shared.PortalMenuItem{
 						Path:       path1,
@@ -280,16 +280,16 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var footerBottom []shared.PortalMenuItem
 		if r.Menu.FooterBottom != nil {
 			footerBottom = make([]shared.PortalMenuItem, 0, len(r.Menu.FooterBottom))
-			for _, footerBottomItem := range r.Menu.FooterBottom {
+			for footerBottomIndex := range r.Menu.FooterBottom {
 				var path2 string
-				path2 = footerBottomItem.Path.ValueString()
+				path2 = r.Menu.FooterBottom[footerBottomIndex].Path.ValueString()
 
 				var title3 string
-				title3 = footerBottomItem.Title.ValueString()
+				title3 = r.Menu.FooterBottom[footerBottomIndex].Title.ValueString()
 
-				visibility2 := shared.Visibility(footerBottomItem.Visibility.ValueString())
+				visibility2 := shared.Visibility(r.Menu.FooterBottom[footerBottomIndex].Visibility.ValueString())
 				var external2 bool
-				external2 = footerBottomItem.External.ValueBool()
+				external2 = r.Menu.FooterBottom[footerBottomIndex].External.ValueBool()
 
 				footerBottom = append(footerBottom, shared.PortalMenuItem{
 					Path:       path2,

--- a/internal/provider/portalpage_resource.go
+++ b/internal/provider/portalpage_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *PortalPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed: true,
@@ -133,9 +129,6 @@ func (r *PortalPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -384,7 +377,10 @@ func (r *PortalPageResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalsnippet_resource.go
+++ b/internal/provider/portalsnippet_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -69,9 +68,6 @@ func (r *PortalSnippetResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed: true,
@@ -123,9 +119,6 @@ func (r *PortalSnippetResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -374,7 +367,10 @@ func (r *PortalSnippetResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalteam_resource.go
+++ b/internal/provider/portalteam_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
-	"github.com/kong/terraform-provider-konnect-beta/internal/validators"
 	"regexp"
 )
 
@@ -58,9 +57,6 @@ func (r *PortalTeamResource) Schema(ctx context.Context, req resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -89,9 +85,6 @@ func (r *PortalTeamResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 		},
@@ -328,7 +321,10 @@ func (r *PortalTeamResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/sdk/assets.go
+++ b/internal/sdk/assets.go
@@ -272,6 +272,7 @@ func (s *Assets) GetPortalAssetLogo(ctx context.Context, request operations.GetP
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -806,6 +807,7 @@ func (s *Assets) GetPortalAssetFavicon(ctx context.Context, request operations.G
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/hostnamegenerator.go
+++ b/internal/sdk/hostnamegenerator.go
@@ -901,6 +901,7 @@ func (s *HostnameGenerator) GetHostnameGeneratorList(ctx context.Context, reques
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/konnectbeta.go
+++ b/internal/sdk/konnectbeta.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 2.0.0 and generator version 2.748.0
+// Generated from OpenAPI doc version 2.0.0 and generator version 2.763.2
 
 import (
 	"context"
@@ -204,7 +204,7 @@ func New(opts ...SDKOption) *KonnectBeta {
 	sdk := &KonnectBeta{
 		SDKVersion: "0.12.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.12.1 2.748.0 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.12.1 2.763.2 2.0.0 github.com/kong/terraform-provider-konnect-beta/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/sdk/mesh.go
+++ b/internal/sdk/mesh.go
@@ -902,6 +902,7 @@ func (s *Mesh) GetMeshList(ctx context.Context, request operations.GetMeshListRe
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -1159,6 +1160,7 @@ func (s *Mesh) ListMeshControlPlanes(ctx context.Context, request operations.Lis
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshaccesslog.go
+++ b/internal/sdk/meshaccesslog.go
@@ -901,6 +901,7 @@ func (s *MeshAccessLog) GetMeshAccessLogList(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshcircuitbreaker.go
+++ b/internal/sdk/meshcircuitbreaker.go
@@ -901,6 +901,7 @@ func (s *MeshCircuitBreaker) GetMeshCircuitBreakerList(ctx context.Context, requ
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshexternalservice.go
+++ b/internal/sdk/meshexternalservice.go
@@ -901,6 +901,7 @@ func (s *MeshExternalService) GetMeshExternalServiceList(ctx context.Context, re
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshfaultinjection.go
+++ b/internal/sdk/meshfaultinjection.go
@@ -901,6 +901,7 @@ func (s *MeshFaultInjection) GetMeshFaultInjectionList(ctx context.Context, requ
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshgateway.go
+++ b/internal/sdk/meshgateway.go
@@ -901,6 +901,7 @@ func (s *MeshGateway) GetMeshGatewayList(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshglobalratelimit.go
+++ b/internal/sdk/meshglobalratelimit.go
@@ -901,6 +901,7 @@ func (s *MeshGlobalRateLimit) GetMeshGlobalRateLimitList(ctx context.Context, re
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshhealthcheck.go
+++ b/internal/sdk/meshhealthcheck.go
@@ -901,6 +901,7 @@ func (s *MeshHealthCheck) GetMeshHealthCheckList(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshhttproute.go
+++ b/internal/sdk/meshhttproute.go
@@ -901,6 +901,7 @@ func (s *MeshHTTPRoute) GetMeshHTTPRouteList(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshidentity.go
+++ b/internal/sdk/meshidentity.go
@@ -901,6 +901,7 @@ func (s *MeshIdentity) GetMeshIdentityList(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshloadbalancingstrategy.go
+++ b/internal/sdk/meshloadbalancingstrategy.go
@@ -901,6 +901,7 @@ func (s *MeshLoadBalancingStrategy) GetMeshLoadBalancingStrategyList(ctx context
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshmetric.go
+++ b/internal/sdk/meshmetric.go
@@ -901,6 +901,7 @@ func (s *MeshMetric) GetMeshMetricList(ctx context.Context, request operations.G
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshmultizoneservice.go
+++ b/internal/sdk/meshmultizoneservice.go
@@ -901,6 +901,7 @@ func (s *MeshMultiZoneService) GetMeshMultiZoneServiceList(ctx context.Context, 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshopa.go
+++ b/internal/sdk/meshopa.go
@@ -901,6 +901,7 @@ func (s *MeshOPA) GetMeshOPAList(ctx context.Context, request operations.GetMesh
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshpassthrough.go
+++ b/internal/sdk/meshpassthrough.go
@@ -901,6 +901,7 @@ func (s *MeshPassthrough) GetMeshPassthroughList(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshproxypatch.go
+++ b/internal/sdk/meshproxypatch.go
@@ -901,6 +901,7 @@ func (s *MeshProxyPatch) GetMeshProxyPatchList(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshratelimit.go
+++ b/internal/sdk/meshratelimit.go
@@ -901,6 +901,7 @@ func (s *MeshRateLimit) GetMeshRateLimitList(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshretry.go
+++ b/internal/sdk/meshretry.go
@@ -901,6 +901,7 @@ func (s *MeshRetry) GetMeshRetryList(ctx context.Context, request operations.Get
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshservice.go
+++ b/internal/sdk/meshservice.go
@@ -901,6 +901,7 @@ func (s *MeshService) GetMeshServiceList(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtcproute.go
+++ b/internal/sdk/meshtcproute.go
@@ -901,6 +901,7 @@ func (s *MeshTCPRoute) GetMeshTCPRouteList(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtimeout.go
+++ b/internal/sdk/meshtimeout.go
@@ -901,6 +901,7 @@ func (s *MeshTimeout) GetMeshTimeoutList(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtls.go
+++ b/internal/sdk/meshtls.go
@@ -901,6 +901,7 @@ func (s *MeshTLS) GetMeshTLSList(ctx context.Context, request operations.GetMesh
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtrace.go
+++ b/internal/sdk/meshtrace.go
@@ -901,6 +901,7 @@ func (s *MeshTrace) GetMeshTraceList(ctx context.Context, request operations.Get
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtrafficpermission.go
+++ b/internal/sdk/meshtrafficpermission.go
@@ -901,6 +901,7 @@ func (s *MeshTrafficPermission) GetMeshTrafficPermissionList(ctx context.Context
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/meshtrust.go
+++ b/internal/sdk/meshtrust.go
@@ -901,6 +901,7 @@ func (s *MeshTrust) GetMeshTrustList(ctx context.Context, request operations.Get
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/portalauthsettings.go
+++ b/internal/sdk/portalauthsettings.go
@@ -254,6 +254,7 @@ func (s *PortalAuthSettings) GetPortalAuthenticationSettings(ctx context.Context
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/secret.go
+++ b/internal/sdk/secret.go
@@ -901,6 +901,7 @@ func (s *Secret) GetSecretList(ctx context.Context, request operations.GetSecret
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/zoneegress.go
+++ b/internal/sdk/zoneegress.go
@@ -901,6 +901,7 @@ func (s *ZoneEgress) GetZoneEgressList(ctx context.Context, request operations.G
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/zoneingress.go
+++ b/internal/sdk/zoneingress.go
@@ -901,6 +901,7 @@ func (s *ZoneIngress) GetZoneIngressList(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/tests/resources/event_gateway_test.go
+++ b/tests/resources/event_gateway_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestEventGateway(t *testing.T) {
@@ -76,12 +75,11 @@ func TestEventGateway(t *testing.T) {
 				},
 				{
 					ProtoV6ProviderFactories: providerFactory,
-					ConfigDirectory:          config.TestNameDirectory(),
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PreApply: []plancheck.PlanCheck{
-							plancheck.ExpectEmptyPlan(),
-						},
-					},
+					ConfigDirectory:          config.TestStepDirectory(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						// Update Event Gateway Virtual Cluster
+						resource.TestCheckResourceAttr("konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster", "description", "description_updated"),
+					),
 				},
 			},
 		})

--- a/tests/resources/testdata/TestEventGateway/smoke-test/2/main-step-2.tf
+++ b/tests/resources/testdata/TestEventGateway/smoke-test/2/main-step-2.tf
@@ -1,0 +1,264 @@
+
+resource "konnect_event_gateway" "my_eventgateway" {
+  provider = konnect-beta
+
+  labels = {
+    key = "values"
+  }
+  name = "myeventgateway"
+}
+
+resource "konnect_event_gateway_listener" "my_eventgatewaylistener" {
+  provider = konnect-beta
+  addresses = [
+    "..."
+  ]
+  description = "description"
+  gateway_id  = konnect_event_gateway.my_eventgateway.id
+  labels = {
+    key = "values"
+  }
+  name = "my-egw-listener"
+  ports = [
+    "25401"
+  ]
+}
+
+resource "konnect_event_gateway_backend_cluster" "my_eventgatewaybackendcluster" {
+  provider = konnect-beta
+    authentication = {
+        sasl_scram = {
+        algorithm = "sha256"
+        password = "$${env['MY_SECRET']}"
+        username = "user"
+    }
+    }
+    bootstrap_servers = [
+        "10.0.0.1:8080"
+    ]
+    tls = {
+        enabled = false
+        insecure_skip_verify = true
+    }
+    description = "description"
+    gateway_id = konnect_event_gateway.my_eventgateway.id
+    insecure_allow_anonymous_virtual_cluster_auth = false
+    metadata_update_interval_seconds = 22808
+    name = "backendname"
+}
+
+resource "konnect_event_gateway_virtual_cluster" "my_eventgatewayvirtualcluster" {
+  provider = konnect-beta
+    authentication = [
+      {
+        sasl_plain = {
+            mediation = "passthrough"
+            principals = [
+              {
+                    password = "$${env['MY_SECRET']}"
+                    username = "my_username"
+              }
+            ]
+        }
+      }
+    ]
+    namespace = {
+      mode = "hide_prefix"
+      prefix = "my_prefix"
+    }
+    description = "description_updated"
+    acl_mode = "enforce_on_gateway"
+    destination = {
+      id = konnect_event_gateway_backend_cluster.my_eventgatewaybackendcluster.id
+    }
+    dns_label = "vcluster-label"
+    gateway_id = konnect_event_gateway.my_eventgateway.id
+    name = "virtualnamex"
+}
+
+resource "konnect_event_gateway_vault" "my_eventgatewayvault" {
+  provider = konnect-beta
+  env = {
+    config = {
+      prefix = "KONG_"
+    }
+    description = "description"
+    name = "myvault"
+  }
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+}
+
+resource "konnect_event_gateway_schema_registry" "my_eventgatewayschemaregistry" {
+  provider = konnect-beta
+  confluent = {
+    config = {
+      authentication = {
+        basic = {
+            password = "$${env['MY_SECRET']}"
+            username = "uname"
+        }
+      }
+      endpoint = "https://example.com"
+      schema_type = "avro"
+      timeout_seconds = 8
+    }
+    description = "description"
+    labels = {
+        key = "value"
+    }
+    name = "confname"
+  }
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+}
+
+
+resource "konnect_event_gateway_listener_policy_forward_to_virtual_cluster" "my_eventgatewaylistenerpolicy" {
+  provider = konnect-beta
+  config = {
+    port_mapping = {
+      advertised_host = "host.example.com"
+      bootstrap_port = "none"
+      destination = {
+        virtual_cluster_reference_by_id = {
+            id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+        }
+      }
+      min_broker_id = 5
+    }
+  }
+  description = "mydesc"
+  enabled = true
+  labels = {
+      key = "value"
+  }
+  name = "listenerpolicyname"
+
+  event_gateway_listener_id = konnect_event_gateway_listener.my_eventgatewaylistener.id
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+}
+
+resource "konnect_event_gateway_static_key" "my_eventgatewaystatickey" {
+  provider = konnect-beta
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+  name = "mytftestkey"
+  value = "$${vault.env['MY_ENV_VAR']}"
+}
+
+resource "konnect_event_gateway_produce_policy_encrypt" "my_eventgatewayproducepolicyencrypt" {
+  provider = konnect-beta
+  condition = "context.topic.name.endsWith('my_suffix')"
+  config = {
+    encryption_key = {
+      static = {
+        key = {
+          reference_by_id = {
+            id = konnect_event_gateway_static_key.my_eventgatewaystatickey.id
+          }
+        }
+      }
+    }
+    failure_mode = "error"
+    part_of_record = [
+      "key"
+    ]
+  }
+  description = "my_description"
+  enabled = true
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+
+  name = "mytftestencryptpolicy"
+  virtual_cluster_id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+}
+
+resource "konnect_event_gateway_consume_policy_decrypt" "my_eventgatewayconsumepolicydecrypt" {
+  provider = konnect-beta
+  condition = "context.topic.name.endsWith('my_suffix')"
+  config = {
+    failure_mode = "passthrough"
+    key_sources = [
+      {
+        static = {
+        }
+      }
+    ]
+    part_of_record = [
+      "key"
+    ]
+  }
+  enabled     = true
+  gateway_id  = konnect_event_gateway.my_eventgateway.id
+  name               = "mytftestconsumedrcryptpolicy"
+  virtual_cluster_id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+}
+
+resource "konnect_event_gateway_produce_policy_modify_headers" "my_eventgatewayvirtualclusterproducepolicy" {
+  provider = konnect-beta
+  virtual_cluster_id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+  condition = "context.topic.name.endsWith('my_suffix')"
+  config = {
+    actions = [
+      {
+        remove = {
+            key = "...my_key..."
+        }
+      }
+    ]
+  }
+  description = "mydesc"
+  enabled = true
+  labels = {
+      key = "value"
+  }
+  name = "myproducename"
+}
+
+resource "konnect_event_gateway_consume_policy_modify_headers" "my_eventgatewayvirtualclusterconsumepolicy" {
+  provider = konnect-beta
+  virtual_cluster_id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+  condition = "context.topic.name.endsWith('my_suffix')"
+  config = {
+    actions = [
+      {
+        remove = {
+          key = "mykey"
+        }
+      }
+    ]
+  }
+  description = "mydescription"
+  enabled     = true
+  labels = {
+    key = "value"
+  }
+  name = "myconsumename"
+}
+
+resource "konnect_event_gateway_cluster_policy_acls" "my_eventgatewayvirtualclusterclusterpolicy" {
+  provider = konnect-beta
+  virtual_cluster_id = konnect_event_gateway_virtual_cluster.my_eventgatewayvirtualcluster.id
+  gateway_id = konnect_event_gateway.my_eventgateway.id
+  condition = "context.topic.name.endsWith('my_suffix')"
+  description = "mydesc"
+  enabled     = true
+  name = "mynamecluster"
+  config = {
+    rules = [
+      {
+        action = "deny"
+        operations = [
+          {
+            name = "read"
+          }
+        ]
+        resource_names = [
+          {
+            match = "my_match"
+          }
+        ]
+        resource_type = "topic"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Summary
 We had a regression in v0.12 when we upgraded speakeasy, which removed handling for a particular oneof type in virtual cluster authentication. This broke the update operation.

This has been fixed in v1.661.1 - https://kongstrong.slack.com/archives/C05MLAA216D/p1763979993474049
Discovered at https://kongstrong.slack.com/archives/C089Z3BMC9Z/p1763737802309409

Some other changes:
Enum properties, and validators are removed from read-only properties, which shouldn't affect the provider.

### Issues resolved
- https://github.com/Kong/terraform-provider-konnect-beta/issues/159

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Features being added are live
- [ ] Added/updated examples (if applicable)  
- [x] Added/updated acceptance tests (if applicable)  
- [x] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
