### PR TITLE
Feat: support auth server clients import with id and secret

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: e3bbe1e9-fe63-436b-a42c-05e3e3f77633
 management:
-  docChecksum: 52c5ca04f693ed23c2788d6269784635
+  docChecksum: 045048d9df8097560de8676b9dda7f7c
   docVersion: 2.0.0
   speakeasyVersion: 1.676.1
   generationVersion: 2.781.2
   releaseVersion: 0.14.0
   configChecksum: bfa214196ab0be882bc29ed6c271d9bf
 persistentEdits:
-  generation_id: b517139d-0fdb-4d83-a173-9bde614ab765
-  pristine_commit_hash: cdad5bea77005b4198292c6bdc12f34a5965fd0d
-  pristine_tree_hash: 2df41463c125adb7900ba949bcd452a53809b379
+  generation_id: 6d329084-a204-4d00-a37c-5e7bc83d37af
+  pristine_commit_hash: f7db4d304fa1f3e7ed54cea227df09139b1a87c3
+  pristine_tree_hash: 0d1643848413ad56814feea1e74211563366494d
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -154,8 +154,8 @@ trackedFiles:
     pristine_git_object: c80bf2c219ae1622f515677d2e6f127473920898
   examples/resources/konnect-beta_auth_server_clients/resource.tf:
     id: 4f79cb66b7aa
-    last_write_checksum: sha1:70116b767d525f5d22a5ed719e57f7939feb6fa6
-    pristine_git_object: 8aebf3f4e00f2ed0c557dc321522e58985fd872a
+    last_write_checksum: sha1:ee5ed5bd46908aca532074bc8e58e447fccec48e
+    pristine_git_object: aa450b8c18729970cb19a380c890676f2480e469
   examples/resources/konnect-beta_auth_server_scopes/import-by-string-id.tf:
     id: 351abdfb74e1
     last_write_checksum: sha1:fa7588c78a97c70b1089add3d1d46853f0e081cc
@@ -994,12 +994,12 @@ trackedFiles:
     pristine_git_object: 7209dcc8c080610d81055c01c774b9a6bfa0fcb9
   internal/provider/authserverclients_resource.go:
     id: da47f1d88fae
-    last_write_checksum: sha1:012806eb8b259cf35d5ae204177ccd7008279897
-    pristine_git_object: c877d6518c23ac15db0a197ce27b1ab0a6ec16d4
+    last_write_checksum: sha1:1b73f51ae6ea6be8aa03860bf8f9e88d2829b00b
+    pristine_git_object: a39567e1a62a218cba28710433f350eab7289648
   internal/provider/authserverclients_resource_sdk.go:
     id: e0c9ec7f117f
-    last_write_checksum: sha1:525c6e4b6db0a63ef0170102a81f87ba8e0f4ff1
-    pristine_git_object: d04e2168455dd2f65f473457088854e6c46610c9
+    last_write_checksum: sha1:7fa1708335dd4149d61eefe82eea2c3445af8eea
+    pristine_git_object: 9ab8cc09e379d39a8f24123c1d6696d260a40fb6
   internal/provider/authserverscopes_resource.go:
     id: a72acbc13263
     last_write_checksum: sha1:8b059c4d7b3ef199d435826d0773f4928e81b341
@@ -4586,8 +4586,8 @@ trackedFiles:
     pristine_git_object: b4083bee0d57be03b59d8a7d18cfe634414b62e4
   internal/sdk/models/shared/createclient.go:
     id: 938c165c046e
-    last_write_checksum: sha1:9a32d20bbf3320c05b1f7154d724320c0b155693
-    pristine_git_object: 2e07b8cccc41bf2912ee04f2db6c267c62b41674
+    last_write_checksum: sha1:10b547f40c3cb7ef48d93453d259e876972a2619
+    pristine_git_object: 286adfa79f7d09de25af5f4e3f1c81a72aa38cd6
   internal/sdk/models/shared/createdclient.go:
     id: 7b57a38b5bdf
     last_write_checksum: sha1:2257b0c2b825999214162c4d647cdd80ae500f55
@@ -9778,7 +9778,7 @@ examples:
         path:
           authServerId: "d32d905a-ed33-46a3-a093-d8f536af9a8a"
       requestBody:
-        application/json: {"name": "<value>", "grant_types": ["client_credentials"], "response_types": [], "login_uri": null, "access_token_duration": 300, "id_token_duration": 300, "allow_all_scopes": false, "labels": {"env": "test"}, "token_endpoint_auth_method": "client_secret_post"}
+        application/json: {"name": "<value>", "grant_types": ["client_credentials"], "response_types": [], "login_uri": null, "access_token_duration": 300, "id_token_duration": 300, "allow_all_scopes": false, "labels": {"env": "test"}, "token_endpoint_auth_method": "client_secret_post", "id": "kYa9iQFU5xPDSIUH9z1z"}
       responses:
         "201":
           application/json: {"id": "kYa9iQFU5xPDSIUH9z1z", "name": "<value>", "grant_types": [], "redirect_uris": ["https://improbable-stitcher.net", "https://caring-switchboard.net"], "login_uri": null, "access_token_duration": 300, "id_token_duration": 300, "allow_all_scopes": false, "allow_scopes": ["ee2ba59e-da21-42fb-8fe0-5795664e508c", "708d5afa-b5af-42bc-b519-345a24cd65bf"], "labels": {"env": "test"}, "response_types": ["none"], "token_endpoint_auth_method": "client_secret_post", "created_at": "2022-11-04T20:10:06.927Z", "updated_at": "2022-11-04T20:10:06.927Z", "client_secret": "YAzsyUlNZ5gNGeKS9H3VAdxVPzhPo4ae"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.0
+> Released on 2026/01/??
+
+### Features
+* Support giving `id` and `client_secret` as input to `konnect_auth_server_clients` resource
+
 ## 0.14.0
 > Released on 2025/12/18
 

--- a/docs/resources/auth_server_clients.md
+++ b/docs/resources/auth_server_clients.md
@@ -21,9 +21,11 @@ resource "konnect_auth_server_clients" "my_authserverclients" {
     "247c0ad0-5487-46a8-bedf-a569c07c2442"
   ]
   auth_server_id = "d32d905a-ed33-46a3-a093-d8f536af9a8a"
+  client_secret  = "YAzsyUlNZ5gNGeKS9H3VAdxVPzhPo4ae"
   grant_types = [
     "authorization_code"
   ]
+  id                = "kYa9iQFU5xPDSIUH9z1z"
   id_token_duration = 961077
   labels = {
     key = "value"
@@ -55,6 +57,8 @@ resource "konnect_auth_server_clients" "my_authserverclients" {
 - `access_token_duration` (Number) The duration of the minted token is valid for, in seconds. Default: 300
 - `allow_all_scopes` (Boolean) Specifies whether the client is allowed to request all scopes. Default: false
 - `allow_scopes` (List of String) Specifies the scopes IDs that the client is allowed to request
+- `client_secret` (String) Secret of the client - will be used when ID is also set.
+- `id` (String) The OAuth 2.0 client ID. Requires replacement if changed.
 - `id_token_duration` (Number) The duration of the minted token is valid for, in seconds. Default: 300
 - `labels` (Map of String) Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. 
 
@@ -65,9 +69,7 @@ Keys must be of length 1-63 characters, and cannot start with "kong", "konnect",
 
 ### Read-Only
 
-- `client_secret` (String) Secret of the client
 - `created_at` (String) An ISO-8601 timestamp representation of entity creation date.
-- `id` (String) The OAuth 2.0 client ID
 - `updated_at` (String) An ISO-8601 timestamp representation of entity update date.
 
 ## Import

--- a/examples/resources/konnect_auth_server_clients/resource.tf
+++ b/examples/resources/konnect_auth_server_clients/resource.tf
@@ -6,9 +6,11 @@ resource "konnect_auth_server_clients" "my_authserverclients" {
     "247c0ad0-5487-46a8-bedf-a569c07c2442"
   ]
   auth_server_id = "d32d905a-ed33-46a3-a093-d8f536af9a8a"
+  client_secret  = "YAzsyUlNZ5gNGeKS9H3VAdxVPzhPo4ae"
   grant_types = [
     "authorization_code"
   ]
+  id                = "kYa9iQFU5xPDSIUH9z1z"
   id_token_duration = 961077
   labels = {
     key = "value"

--- a/internal/provider/authserverclients_resource.go
+++ b/internal/provider/authserverclients_resource.go
@@ -17,11 +17,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect-beta/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect-beta/internal/sdk"
+	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -96,7 +98,8 @@ func (r *AuthServerClientsResource) Schema(ctx context.Context, req resource.Sch
 			},
 			"client_secret": schema.StringAttribute{
 				Computed:    true,
-				Description: `Secret of the client`,
+				Optional:    true,
+				Description: `Secret of the client - will be used when ID is also set.`,
 			},
 			"created_at": schema.StringAttribute{
 				Computed: true,
@@ -115,10 +118,16 @@ func (r *AuthServerClientsResource) Schema(ctx context.Context, req resource.Sch
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
+				Optional: true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Description: `The OAuth 2.0 client ID`,
+				Description: `The OAuth 2.0 client ID. Requires replacement if changed.`,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthBetween(1, 36),
+					stringvalidator.RegexMatches(regexp.MustCompile(`[-_\w]+`), "must match pattern "+regexp.MustCompile(`[-_\w]+`).String()),
+				},
 			},
 			"id_token_duration": schema.Int64Attribute{
 				Computed:    true,

--- a/internal/provider/authserverclients_resource_sdk.go
+++ b/internal/provider/authserverclients_resource_sdk.go
@@ -242,6 +242,18 @@ func (r *AuthServerClientsResourceModel) ToSharedCreateClient(ctx context.Contex
 	} else {
 		tokenEndpointAuthMethod = nil
 	}
+	id := new(string)
+	if !r.ID.IsUnknown() && !r.ID.IsNull() {
+		*id = r.ID.ValueString()
+	} else {
+		id = nil
+	}
+	clientSecret := new(string)
+	if !r.ClientSecret.IsUnknown() && !r.ClientSecret.IsNull() {
+		*clientSecret = r.ClientSecret.ValueString()
+	} else {
+		clientSecret = nil
+	}
 	out := shared.CreateClient{
 		Name:                    name,
 		GrantTypes:              grantTypes,
@@ -254,6 +266,8 @@ func (r *AuthServerClientsResourceModel) ToSharedCreateClient(ctx context.Contex
 		AllowScopes:             allowScopes,
 		Labels:                  labels,
 		TokenEndpointAuthMethod: tokenEndpointAuthMethod,
+		ID:                      id,
+		ClientSecret:            clientSecret,
 	}
 
 	return &out, diags

--- a/internal/sdk/internal/hooks/auth_server_clients_hook.go
+++ b/internal/sdk/internal/hooks/auth_server_clients_hook.go
@@ -1,0 +1,64 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+// struct that implements the BeforeRequestHook interface.
+type AuthServerClientCreateHook struct{}
+
+var konnectMatchAuthServerClientCreate = func(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+
+	match, err := regexp.MatchString(`^/v1/auth-servers/[^/]+/clients$`, req.URL.Path)
+	if err != nil {
+		return false
+	}
+
+	return match && req.Method == http.MethodPost
+}
+
+// BeforeRequest modifies the request before sending it.
+func (e AuthServerClientCreateHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	if konnectMatchAuthServerClientCreate(req) {
+		// Change to PUT if creating with ID
+		var bodyMap map[string]interface{}
+
+		if req.Body != nil {
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			defer req.Body.Close()
+
+			if len(bodyBytes) > 0 {
+				if err := json.Unmarshal(bodyBytes, &bodyMap); err != nil {
+					return nil, err
+				}
+
+				// Check if "id" field exists, if yes, use PUT to preserve the ID
+				id, exists := bodyMap["id"]
+				if idStr, ok := id.(string); ok && exists && idStr != "" {
+					req.URL.Path = req.URL.Path + "/" + idStr
+					req.Method = http.MethodPut
+				}
+
+				newBody, err := json.Marshal(bodyMap)
+				if err != nil {
+					return nil, err
+				}
+
+				req.Body = io.NopCloser(bytes.NewReader(newBody))
+				req.ContentLength = int64(len(newBody))
+			}
+		}
+	}
+
+	return req, nil
+}

--- a/internal/sdk/internal/hooks/auth_server_clients_hook_test.go
+++ b/internal/sdk/internal/hooks/auth_server_clients_hook_test.go
@@ -1,0 +1,102 @@
+package hooks
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthServerClientCreateHook_BeforeRequest(t *testing.T) {
+	testCases := []struct {
+		name           string
+		req            *http.Request
+		expectedMethod string
+		expectedPath   string
+		expectedBody   string
+		expectError    bool
+	}{
+		{
+			name: "converts POST with id to PUT",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Path: "/v1/auth-servers/server-123/clients",
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"id":"client-456","name":"test-client"}`)),
+			},
+			expectedMethod: http.MethodPut,
+			expectedPath:   "/v1/auth-servers/server-123/clients/client-456",
+			expectedBody:   `{"id":"client-456","name":"test-client"}`,
+			expectError:    false,
+		},
+		{
+			name: "keeps POST when no id field",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Path: "/v1/auth-servers/server-123/clients",
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"name":"test-client"}`)),
+			},
+			expectedMethod: http.MethodPost,
+			expectedPath:   "/v1/auth-servers/server-123/clients",
+			expectedBody:   `{"name":"test-client"}`,
+			expectError:    false,
+		},
+		{
+			name: "keeps POST when id is empty string",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Path: "/v1/auth-servers/server-123/clients",
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"id":"","name":"test-client"}`)),
+			},
+			expectedMethod: http.MethodPost,
+			expectedPath:   "/v1/auth-servers/server-123/clients",
+			expectedBody:   `{"id":"","name":"test-client"}`,
+			expectError:    false,
+		},
+		{
+			name: "does not modify non-matching requests",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Path: "/v1/other-endpoint",
+				},
+				Body: io.NopCloser(bytes.NewBufferString(`{"id":"test-123"}`)),
+			},
+			expectedMethod: http.MethodPost,
+			expectedPath:   "/v1/other-endpoint",
+			expectedBody:   `{"id":"test-123"}`,
+			expectError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := AuthServerClientCreateHook{}
+			result, err := hook.BeforeRequest(BeforeRequestContext{}, tc.req)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tc.expectedMethod, result.Method)
+			assert.Equal(t, tc.expectedPath, result.URL.Path)
+
+			bodyBytes, err := io.ReadAll(result.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expectedBody, string(bodyBytes))
+		})
+	}
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -1,11 +1,12 @@
 package hooks
 
-import(
-"os"
+import (
+	"os"
 )
 
 func initHooks(h *Hooks) {
-    h.registerBeforeRequestHook(&MeshDefaultsHook{})
+	h.registerBeforeRequestHook(&MeshDefaultsHook{})
+	h.registerBeforeRequestHook(&AuthServerClientCreateHook{})
 
 	// Debug hooks - dump request/response
 	h.registerBeforeRequestHook(&HTTPDumpRequestHook{

--- a/internal/sdk/models/shared/createclient.go
+++ b/internal/sdk/models/shared/createclient.go
@@ -33,6 +33,10 @@ type CreateClient struct {
 	Labels map[string]*string `json:"labels,omitempty"`
 	// Requested authentication method for OAuth 2.0 endpoints.
 	TokenEndpointAuthMethod *TokenEndpointAuthMethod `default:"client_secret_post" json:"token_endpoint_auth_method"`
+	// The OAuth 2.0 client ID
+	ID *string `json:"id,omitempty"`
+	// Secret of the client - will be used when ID is also set.
+	ClientSecret *string `json:"client_secret,omitempty"`
 }
 
 func (c CreateClient) MarshalJSON() ([]byte, error) {
@@ -121,4 +125,18 @@ func (c *CreateClient) GetTokenEndpointAuthMethod() *TokenEndpointAuthMethod {
 		return nil
 	}
 	return c.TokenEndpointAuthMethod
+}
+
+func (c *CreateClient) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
+}
+
+func (c *CreateClient) GetClientSecret() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ClientSecret
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22625,6 +22625,8 @@ components:
         - authorization_code
         - implicit
         - client_credentials
+      x-enum-dev:
+        - authorization_code
       x-speakeasy-unknown-values: allow
     GrantTypes:
       description: List of OAuth 2.0 grant types
@@ -22944,13 +22946,15 @@ components:
         - redirect_uris
         - allow_all_scopes
         - allow_scopes
-        - login_uri
         - access_token_duration
         - id_token_duration
         - labels
         - response_types
         - created_at
         - updated_at
+      x-property-annotations:
+        login_uri:
+          - x-unstable
     CreatedClient:
       allOf:
         - $ref: '#/components/schemas/Client'
@@ -28389,10 +28393,24 @@ components:
                 $ref: '#/components/schemas/Labels'
               token_endpoint_auth_method:
                 $ref: '#/components/schemas/TokenEndpointAuthMethod'
+              id:
+                description: The OAuth 2.0 client ID
+                type: string
+                example: kYa9iQFU5xPDSIUH9z1z
+                maxLength: 36
+                pattern: '[-_\w]+'
+                x-speakeasy-param-computed: true
+              client_secret:
+                description: Secret of the client - will be used when ID is also set.
+                type: string
+                x-speakeasy-param-computed: true
             required:
               - name
               - grant_types
               - response_types
+            x-property-annotations:
+              login_uri:
+                - x-unstable
     ReplaceClient:
       description: Client to be replaced
       required: true
@@ -28432,6 +28450,9 @@ components:
               - client_secret
               - grant_types
               - response_types
+            x-property-annotations:
+              login_uri:
+                - x-unstable
     CreateEventGatewayListenerRequest:
       description: The request schema for creating a listener.
       content:

--- a/tests/resources/auth_server_clients_test.go
+++ b/tests/resources/auth_server_clients_test.go
@@ -126,7 +126,7 @@ func TestAuthServerClients(t *testing.T) {
 		authServerClient.AddAttribute("id", uuidResource.ResourcePath()+".id")
 
 		resource.Test(t, resource.TestCase{
-			ProtoV6ProviderFactories: providerFactoryWithRandom,
+			ProtoV6ProviderFactories: providerFactory,
 			ExternalProviders: map[string]resource.ExternalProvider{
 				"random": {Source: "hashicorp/random"},
 			},

--- a/tests/resources/auth_server_clients_test.go
+++ b/tests/resources/auth_server_clients_test.go
@@ -79,8 +79,6 @@ func TestAuthServerClients(t *testing.T) {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "name", "my-client-without-id"),
-						resource.TestCheckResourceAttrSet("konnect_auth_server_clients.my_client", "id"),
 						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "allow_all_scopes", "false"),
 					),
 				},
@@ -90,7 +88,6 @@ func TestAuthServerClients(t *testing.T) {
 
 	// To be enabled once the provider supports ID and client secret in input for auth server clients
 	t.Run("should do CRUD when ID and client secret are given in input", func(t *testing.T) {
-		t.Skip()
 		builder := hclbuilder.NewWithProvider(hclbuilder.KonnectBeta, fmt.Sprintf("%s://%s:%d", serverScheme, serverHost, serverPort))
 		builder.ProviderProperty = hclbuilder.KonnectBeta
 
@@ -120,16 +117,22 @@ func TestAuthServerClients(t *testing.T) {
 			`)
 		require.NoError(t, err)
 
-		uuidResource, err := hclbuilder.FromString(`resource "random_uuid" "example" {}`)
+		uuidResource, err := hclbuilder.FromString(`resource "random_id" "example" {
+		  byte_length = 16
+		}
+		`)
 		require.NoError(t, err)
 
 		authServerClient.AddAttribute("id", uuidResource.ResourcePath()+".id")
 
-		resource.ParallelTest(t, resource.TestCase{
-			ProtoV6ProviderFactories: providerFactory,
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactoryWithRandom,
+			ExternalProviders: map[string]resource.ExternalProvider{
+				"random": {Source: "hashicorp/random"},
+			},
 			Steps: []resource.TestStep{
 				{
-					Config: builder.Upsert(authServer).Upsert(authServerClient).Build(),
+					Config: builder.Upsert(authServer).Upsert(uuidResource).Upsert(authServerClient).Build(),
 					ConfigPlanChecks: resource.ConfigPlanChecks{
 						PreApply: []plancheck.PlanCheck{
 							plancheck.ExpectResourceAction("konnect_auth_server.my_authserver", plancheck.ResourceActionCreate),
@@ -137,7 +140,20 @@ func TestAuthServerClients(t *testing.T) {
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "name", "my-client-without-id"),
-						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "id", uuidResource.ResourcePath()+".id"),
+						resource.TestCheckResourceAttrPair("konnect_auth_server_clients.my_client", "id", "random_id.example", "id"),
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "client_secret", "YAzsyUlNZ5gNGeKS9H3VAdxVPzhPo4ae"),
+					),
+				},
+				// Update
+				{
+					Config: builder.Upsert(authServer).Upsert(uuidResource).Upsert(authServerClient.AddAttribute("allow_all_scopes", "false")).Build(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("konnect_auth_server_clients.my_client", plancheck.ResourceActionUpdate),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "allow_all_scopes", "false"),
 					),
 				},
 			},

--- a/tests/resources/auth_server_clients_test.go
+++ b/tests/resources/auth_server_clients_test.go
@@ -1,0 +1,146 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Kong/shared-speakeasy/hclbuilder"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	testAuthServer = `
+resource "konnect_auth_server" "my_authserver" {
+  provider = konnect-beta
+
+  name     = "tf-ci-testing-authserver-for-client"
+  audience = "local-demo"
+}
+`
+)
+
+func TestAuthServerClients(t *testing.T) {
+	serverHost, serverPort, serverScheme := providerConfigFromEnv()
+
+	t.Run("should do CRUD when ID is not given", func(t *testing.T) {
+		builder := hclbuilder.NewWithProvider(hclbuilder.KonnectBeta, fmt.Sprintf("%s://%s:%d", serverScheme, serverHost, serverPort))
+		builder.ProviderProperty = hclbuilder.KonnectBeta
+
+		authServer, err := hclbuilder.FromString(testAuthServer)
+		require.NoError(t, err)
+
+		authServerClient, err := hclbuilder.FromString(`resource "konnect_auth_server_clients" "my_client" {
+			provider = konnect-beta
+
+			name             = "my-client-without-id"
+			allow_all_scopes = true
+			grant_types = [
+				"client_credentials",
+				"authorization_code",
+				"implicit"
+			]
+
+			response_types = [
+				"id_token",
+				"token",
+				"code"
+			]
+
+			auth_server_id = konnect_auth_server.my_authserver.id
+			}
+			`)
+		require.NoError(t, err)
+
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: builder.Upsert(authServer).Upsert(authServerClient).Build(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("konnect_auth_server.my_authserver", plancheck.ResourceActionCreate),
+							plancheck.ExpectResourceAction("konnect_auth_server_clients.my_client", plancheck.ResourceActionCreate),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "name", "my-client-without-id"),
+						resource.TestCheckResourceAttrSet("konnect_auth_server_clients.my_client", "id"),
+					),
+				},
+				// Update
+				{
+					Config: builder.Upsert(authServer).Upsert(authServerClient.AddAttribute("allow_all_scopes", "false")).Build(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("konnect_auth_server_clients.my_client", plancheck.ResourceActionUpdate),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "name", "my-client-without-id"),
+						resource.TestCheckResourceAttrSet("konnect_auth_server_clients.my_client", "id"),
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "allow_all_scopes", "false"),
+					),
+				},
+			},
+		})
+	})
+
+	// To be enabled once the provider supports ID and client secret in input for auth server clients
+	t.Run("should do CRUD when ID and client secret are given in input", func(t *testing.T) {
+		t.Skip()
+		builder := hclbuilder.NewWithProvider(hclbuilder.KonnectBeta, fmt.Sprintf("%s://%s:%d", serverScheme, serverHost, serverPort))
+		builder.ProviderProperty = hclbuilder.KonnectBeta
+
+		authServer, err := hclbuilder.FromString(testAuthServer)
+		require.NoError(t, err)
+
+		authServerClient, err := hclbuilder.FromString(`resource "konnect_auth_server_clients" "my_client" {
+			provider = konnect-beta
+
+			name             = "my-client-without-id"
+			allow_all_scopes = true
+			grant_types = [
+				"client_credentials",
+				"authorization_code",
+				"implicit"
+			]
+			client_secret  = "YAzsyUlNZ5gNGeKS9H3VAdxVPzhPo4ae"
+
+			response_types = [
+				"id_token",
+				"token",
+				"code"
+			]
+
+			auth_server_id = konnect_auth_server.my_authserver.id
+			}
+			`)
+		require.NoError(t, err)
+
+		uuidResource, err := hclbuilder.FromString(`resource "random_uuid" "example" {}`)
+		require.NoError(t, err)
+
+		authServerClient.AddAttribute("id", uuidResource.ResourcePath()+".id")
+
+		resource.ParallelTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config: builder.Upsert(authServer).Upsert(authServerClient).Build(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("konnect_auth_server.my_authserver", plancheck.ResourceActionCreate),
+						},
+					},
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "name", "my-client-without-id"),
+						resource.TestCheckResourceAttr("konnect_auth_server_clients.my_client", "id", uuidResource.ResourcePath()+".id"),
+					),
+				},
+			},
+		})
+	})
+}

--- a/tests/resources/provider_test.go
+++ b/tests/resources/provider_test.go
@@ -15,11 +15,6 @@ var (
 		"konnect":      providerserver.NewProtocol6WithError(provider.New("")()),
 		"konnect-beta": providerserver.NewProtocol6WithError(provider.New("")()),
 	}
-
-	providerFactoryWithRandom = map[string]func() (tfprotov6.ProviderServer, error){
-		"konnect":      providerserver.NewProtocol6WithError(provider.New("")()),
-		"konnect-beta": providerserver.NewProtocol6WithError(provider.New("")()),
-	}
 )
 
 func providerConfigFromEnv() (string, int, string) {

--- a/tests/resources/provider_test.go
+++ b/tests/resources/provider_test.go
@@ -15,6 +15,11 @@ var (
 		"konnect":      providerserver.NewProtocol6WithError(provider.New("")()),
 		"konnect-beta": providerserver.NewProtocol6WithError(provider.New("")()),
 	}
+
+	providerFactoryWithRandom = map[string]func() (tfprotov6.ProviderServer, error){
+		"konnect":      providerserver.NewProtocol6WithError(provider.New("")()),
+		"konnect-beta": providerserver.NewProtocol6WithError(provider.New("")()),
+	}
 )
 
 func providerConfigFromEnv() (string, int, string) {


### PR DESCRIPTION
### Summary
In this PR, we are allowing importing auth server clients while preserving the ID and client_secret - using a beforerequest hook.

The hook switches to `PUT` instead of `POST` when `id` is detected.

Callout: If ID is given by user, `client_secret` is expected as well, since it is a required field in `PUT`
  
### Issues resolved
- https://kongstrong.slack.com/archives/C088U0R6JMP/p1757958589620189

### Related PRs on platform-api (if any)
- https://github.com/Kong/platform-api/pull/2154

### Checklist ✅ 
- [x] Features being added are live
- [x] Added/updated examples (if applicable)  
- [x] Added/updated acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [ ] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
