### PR TITLE
test(mesh): assert new sni matcher in MTP checks

### DIFF
--- a/tests/resources/mesh_test.go
+++ b/tests/resources/mesh_test.go
@@ -389,6 +389,7 @@ resource "konnect_mesh_traffic_permission" "allow_all" {
 								knownvalue.ObjectExact(map[string]knownvalue.Check{
 									"allow": knownvalue.ListExact([]knownvalue.Check{
 										knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"sni": knownvalue.Null(),
 											"spiffe_id": knownvalue.ObjectExact(map[string]knownvalue.Check{
 												"type":  knownvalue.StringExact("Exact"),
 												"value": knownvalue.StringExact("spiffe://hello/world"),
@@ -422,6 +423,7 @@ resource "konnect_mesh_traffic_permission" "allow_all" {
 								knownvalue.ObjectExact(map[string]knownvalue.Check{
 									"deny": knownvalue.ListExact([]knownvalue.Check{
 										knownvalue.ObjectExact(map[string]knownvalue.Check{
+											"sni": knownvalue.Null(),
 											"spiffe_id": knownvalue.ObjectExact(map[string]knownvalue.Check{
 												"type":  knownvalue.StringExact("Exact"),
 												"value": knownvalue.StringExact("spiffe://hello/world"),


### PR DESCRIPTION
## Motivation

`TestMesh/create_a_policy_and_remove_arrays_on_it` fails on this branch because the mesh spec added an `sni` matcher next to `spiffe_id` in `MeshTrafficPermission` `allow` / `deny` / `allow_with_shadow_deny` entries.
The test asserts the refreshed match object with `knownvalue.ObjectExact` listing only `spiffe_id`, so the new attribute trips `extra attribute(s): "sni"`.

Failure: <https://github.com/Kong/terraform-provider-konnect-beta/actions/runs/30893003065/job/91953135757>

## Summary

Provider is fine - only the test assertion was stale.
Added `"sni": knownvalue.Null()` to both inner match checks (step 1 `allow`, step 3 `deny`).

Targets `feat/ai-gateway-2.0` because that's where the new `sni` schema lives - on `main` the assertion would be wrong.

Note: the same job also has `TestCloudGatewayAddOn` failing with `Resource Already Exists` on `konnect_gateway_control_plane.test_cp` - leftover control plane from an earlier run, unrelated to this change.

### Issues resolved

- none

### Related PRs on platform-api (if any)

- none

### Checklist ✅

- [ ] Features being added are live
- [ ] Added/updated examples (if applicable)
- [x] Added/updated acceptance tests (if applicable)
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)